### PR TITLE
Include a status: error when we have errors.

### DIFF
--- a/ichnaea/tests/test_views.py
+++ b/ichnaea/tests/test_views.py
@@ -61,7 +61,8 @@ class TestSearch(TestCase):
         res = app.post_json('/v1/search', {"cell": []}, status=400)
         self.assertEqual(res.content_type, 'application/json')
         self.assertTrue('errors' in res.json)
-        self.assertFalse('status' in res.json)
+        self.assertTrue('status' in res.json)
+        self.assertEquals(res.json['status'], 'error')
 
     def test_error_unknown_key(self):
         app = _make_app()
@@ -212,7 +213,7 @@ class TestMeasure(TestCase):
             status=400)
         self.assertEqual(res.content_type, 'application/json')
         self.assertTrue('errors' in res.json)
-        self.assertFalse('status' in res.json)
+        self.assertEquals(res.json['status'], 'error')
 
     def test_error_unknown_key(self):
         app = _make_app()

--- a/ichnaea/views.py
+++ b/ichnaea/views.py
@@ -10,7 +10,7 @@ from ichnaea.submit import submit_request
 
 class _JSONError(HTTPError):
     def __init__(self, errors, status=400):
-        body = {'errors': errors}
+        body = {'status': 'error', 'errors': errors}
         Response.__init__(self, dumps(body))
         self.status = status
         self.content_type = 'application/json'
@@ -128,6 +128,7 @@ def search_post(request):
     .. code-block:: javascript
 
         {
+            "status": "error,
             "errors": {}
         }
 
@@ -208,6 +209,7 @@ def submit_post(request):
     .. code-block:: javascript
 
         {
+            "status": "error",
             "errors": {}
         }
 


### PR DESCRIPTION
I thought that would be better to have a "status" key in the error responses, like what cornice does by default.
