### PR TITLE
Fix unvarred variable in stats graph script

### DIFF
--- a/ichnaea/content/templates/stats.pt
+++ b/ichnaea/content/templates/stats.pt
@@ -133,6 +133,7 @@ function make_graph(url, graph_id) {
     });
 
     var entries = [];
+    var item;
     for (var i = 0; i < result.histogram.length; i++) {
         item = result.histogram[i];
         entries.push({x: Date.parse(item.day), y: item.num});


### PR DESCRIPTION
I think this might fix the graphs not displaying in IE11, although I haven't had a chance to test - certainly shouldn't hurt anyway :-)
