### PR TITLE
removed raven section from heka configuration until import error is resolved

### DIFF
--- a/ichnaea.ini
+++ b/ichnaea.ini
@@ -16,8 +16,3 @@ severity = 4
 stream_class = heka.streams.UdpStream
 stream_host = localhost
 stream_port = 5565
-
-[heka_plugin_raven]
-provider = heka_raven.raven_plugin:config_plugin
-dsn = udp://ea764ba3854747bb986ed5329d0e7485:6d6bd4b3c0ee4dd093319e1dc0f16672@localhost:9001/2
-override = True


### PR DESCRIPTION
An import error occurs when the server is started up, but no error occurs during test runs, so I've commented out the raven plugin for now.
