### PR TITLE
ROW_FORMAT=COMPRESSED and KEY_BLOCK_SIZE requires innodb_file_per_table.

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -15,6 +15,7 @@ just three changes you need to do. For example via the my.cnf:
     innodb_file_format=Barracuda
     innodb_strict_mode=on
     sql-mode="STRICT_TRANS_TABLES"
+    innodb_file_per_table=1
 
 
 Code


### PR DESCRIPTION
Warning,1478,"InnoDB: KEY_BLOCK_SIZE requires innodb_file_per_table."
Warning,1478,"InnoDB: ROW_FORMAT=COMPRESSED requires innodb_file_per_table."
Error,1005,"Can't create table 'location.cell_measure' (errno: 1478)"

Tested on MySQL 5.5.33 (debian 7.3)

http://dev.mysql.com/doc/refman/5.7/en/innodb-compression-syntax-warnings.html
