### PR TITLE
better consistency for field usage with heka timers and counters

### DIFF
--- a/ichnaea/heka_logging.py
+++ b/ichnaea/heka_logging.py
@@ -31,7 +31,7 @@ def heka_tween_factory(handler, registry):
 
     def heka_tween(request):
         with registry.heka_client.timer('http.request',
-                                        fields={'url': request.url}):
+                                        fields={'url_path': request.path}):
             try:
                 response = handler(request)
             except Exception:

--- a/ichnaea/service/search/tests/test_views.py
+++ b/ichnaea/service/search/tests/test_views.py
@@ -34,7 +34,12 @@ class TestSearch(AppTestCase):
 
         find_msg = self.find_heka_messages
         self.assertEquals(1, len(find_msg('counter', 'http.request')))
-        self.assertEquals(1, len(find_msg('timer', 'http.request')))
+        timer_msgs = find_msg('timer', 'http.request')
+
+        self.assertEquals(1, len(timer_msgs))
+        msg = timer_msgs[0]
+        f = [f for f in msg.fields if f.name == 'url_path'][0]
+        self.assertEquals(f.value_string, ['/v1/search'])
 
     def test_ok_wifi(self):
         app = self.app
@@ -59,7 +64,12 @@ class TestSearch(AppTestCase):
 
         find_msg = self.find_heka_messages
         self.assertEquals(1, len(find_msg('counter', 'http.request')))
-        self.assertEquals(1, len(find_msg('timer', 'http.request')))
+        timer_msgs = find_msg('timer', 'http.request')
+
+        self.assertEquals(1, len(timer_msgs))
+        msg = timer_msgs[0]
+        f = [f for f in msg.fields if f.name == 'url_path'][0]
+        self.assertEquals(f.value_string, ['/v1/search'])
 
     def test_wifi_too_few_candidates(self):
         app = self.app


### PR DESCRIPTION
- changes heka timers to use capture the request.path instead of request.url
- saves just the request.path instead of the full URL in the heka timer
