### PR TITLE
Change heartbeat view to do a DB query, close #128

### DIFF
--- a/ichnaea/service/heartbeat/views.py
+++ b/ichnaea/service/heartbeat/views.py
@@ -1,6 +1,10 @@
 import socket
 
 from pyramid.view import view_config
+from pyramid.response import Response
+from pyramid.httpexceptions import HTTPServiceUnavailable
+from sqlalchemy.sql import select
+from sqlalchemy.sql import func
 
 LOCAL_FQDN = socket.getfqdn()
 
@@ -11,4 +15,14 @@ def configure_heartbeat(config):
 
 @view_config(renderer='json', name="__heartbeat__")
 def heartbeat_view(request):
-    return {'status': 'OK', 'hostname': LOCAL_FQDN}
+
+    session = request.db_slave_session
+    conn = session.connection()
+
+    try:
+        if conn.execute(select([func.now()])).first() is None:
+            return HTTPServiceUnavailable()
+        else:
+            return {'status': 'OK', 'hostname': LOCAL_FQDN}
+    except:
+        return HTTPServiceUnavailable()


### PR DESCRIPTION
I confirmed that this is actually sending a query through to mysql by enabling the mysql general query log:

```
140307 16:24:35    39 Query     SELECT now() AS now_1
140307 16:24:36    39 Query     SELECT now() AS now_1
140307 16:24:37    39 Query     SELECT now() AS now_1
```

I also confirmed that when I change the query to something that mysql chokes on, I get a proper HTTP 503 response code. If mysql itself completely falls over, sqlalchemy fails to connect and we get a more general HTTP 500 failure. Hopefully it's enough to make the load balancer drop us.
