### PR TITLE
Truncate 'time' field of measurements to nearest month, close #87

### DIFF
--- a/ichnaea/service/submit/tasks.py
+++ b/ichnaea/service/submit/tasks.py
@@ -115,8 +115,8 @@ def process_time(measure, utcnow, utcmin):
         # time values more than 60 days in the past
         if measure['time'] > utcnow or measure['time'] < utcmin:
             measure['time'] = utcnow
-    # cut down the time to a daily resolution
-    measure['time'] = measure['time'].date()
+    # cut down the time to a monthly resolution
+    measure['time'] = measure['time'].date().replace(day=1)
     return measure
 
 

--- a/ichnaea/service/submit/tests/test_views.py
+++ b/ichnaea/service/submit/tests/test_views.py
@@ -28,6 +28,10 @@ class TestSubmit(CeleryAppTestCase):
     def test_ok_cell(self):
         app = self.app
         today = datetime.utcnow().date()
+        month_rounded_today = today.replace(day=1)
+        month_rounded_dt = datetime(month_rounded_today.year,
+                                    month_rounded_today.month,
+                                    month_rounded_today.day)
 
         cell_data = [
             {"radio": "umts", "mcc": 123, "mnc": 1, "lac": 2, "cid": 1234}]
@@ -56,6 +60,7 @@ class TestSubmit(CeleryAppTestCase):
         item = cell_result[0]
         self.assertEqual(item.measure_id, measure_result[0].id)
         self.assertEqual(item.created.date(), today)
+        self.assertEqual(item.time, month_rounded_dt)
         self.assertEqual(item.lat, 123456781)
         self.assertEqual(item.lon, 234567892)
         self.assertEqual(item.accuracy, 10)
@@ -91,6 +96,10 @@ class TestSubmit(CeleryAppTestCase):
         app = self.app
         today = datetime.utcnow().date()
         wifi_data = [{"key": "0012AB12AB12"}, {"key": "00:34:cd:34:cd:34"}]
+        month_rounded_today = today.replace(day=1)
+        month_rounded_dt = datetime(month_rounded_today.year,
+                                    month_rounded_today.month,
+                                    month_rounded_today.day)
         res = app.post_json(
             '/v1/submit', {"items": [{"lat": 12.3456781,
                                       "lon": 23.4567892,
@@ -108,6 +117,7 @@ class TestSubmit(CeleryAppTestCase):
         item = wifi_result[0]
         self.assertEqual(item.measure_id, measure_result[0].id)
         self.assertEqual(item.created.date(), today)
+        self.assertEqual(item.time, month_rounded_dt)
         self.assertEqual(item.lat, 123456781)
         self.assertEqual(item.lon, 234567892)
         self.assertEqual(item.accuracy, 17)
@@ -189,16 +199,20 @@ class TestSubmit(CeleryAppTestCase):
         wifis = dict([(w.key, (w.created, w.time)) for w in result])
         today = datetime.utcnow().date()
 
+        month_rounded_tday = time.replace(day=1, hour=0, minute=0, second=0)
+        month_rounded_today = today.replace(day=1)
+
         self.assertEqual(wifis['00aaaaaaaaaa'][0].date(), today)
-        self.assertEqual(wifis['00aaaaaaaaaa'][1], tday)
+        self.assertEqual(wifis['00aaaaaaaaaa'][1], month_rounded_tday)
 
         self.assertEqual(wifis['00bbbbbbbbbb'][0].date(), today)
-        self.assertEqual(wifis['00bbbbbbbbbb'][1].date(), today)
+        self.assertEqual(wifis['00bbbbbbbbbb'][1].date(), month_rounded_today)
 
     def test_time_short_format(self):
         app = self.app
         # a string like "2014-01-15"
         time = datetime.utcnow().date()
+        month_rounded_time = time.replace(day=1)
         tstr = time.isoformat()
         app.post_json(
             '/v1/submit', {"items": [
@@ -211,7 +225,7 @@ class TestSubmit(CeleryAppTestCase):
         result = session.query(WifiMeasure).all()
         self.assertEqual(len(result), 1)
         result_time = result[0].time
-        self.assertEqual(result_time.date(), time)
+        self.assertEqual(result_time.date(), month_rounded_time)
         self.assertEqual(result_time.hour, 0)
         self.assertEqual(result_time.minute, 0)
         self.assertEqual(result_time.second, 0)

--- a/ichnaea/tasks.py
+++ b/ichnaea/tasks.py
@@ -321,7 +321,7 @@ def trim_excessive_data(session, unique_model, measure_model,
     # with periodic recent-stat calculations on incoming new data
     utcnow = datetime.utcnow()
     age_threshold = utcnow - timedelta(days=min_age_days)
-    age_cond = measure_model.time < age_threshold
+    age_cond = measure_model.created < age_threshold
 
     # initial (fast) query to pull out those uniques that have
     # total_measures larger than max_measures; will refine this

--- a/ichnaea/tests/test_importer.py
+++ b/ichnaea/tests/test_importer.py
@@ -52,7 +52,7 @@ class TestLoadFile(CeleryTestCase):
         self.assertEqual(measure.altitude, 500)
         self.assertEqual(measure.altitude_accuracy, 0)
         self.assertEqual(measure.created.date(), today)
-        self.assertEqual(measure.time.date(), today)
+        self.assertEqual(measure.time.date(), today.replace(day=1))
 
     def test_batch(self):
         func, tmpfile = self._make_one()

--- a/ichnaea/tests/test_tasks.py
+++ b/ichnaea/tests/test_tasks.py
@@ -320,6 +320,7 @@ class TestWifiLocationUpdate(CeleryTestCase):
             measures.append(unique_model(lat=(m1 + m2) / 2, lon=(m1 + m2) / 2,
                                          total_measures=measures_per_key * 2,
                                          **kargs))
+            kargs['created'] = backdate
             kargs['time'] = backdate
             for i in range(measures_per_key):
                 measures.append(measure_model(lat=m1 + i, lon=m1 + i, **kargs))


### PR DESCRIPTION
Also switch ichnaea.tasks.trim_excessive_data to use 'created'
to judge the amount of time a measure has been in the DB, rather
than 'time'. This condition is used to keep records around long
enough to get summarized into the stats tables, so 'created' is
the correct field to consider; using 'time' was an unreported bug.
