### PR TITLE
Added a simple top-20 seven-day leaderboard

### DIFF
--- a/ichnaea/content/stats.py
+++ b/ichnaea/content/stats.py
@@ -99,6 +99,40 @@ def leaders(session):
     return result
 
 
+def leaders_weekly(session, batch=20):
+    result = {'new_cell': [], 'new_wifi': []}
+    today = datetime.datetime.utcnow().date()
+    one_week = today - timedelta(7)
+
+    score_rows = {}
+    userids = set()
+    for name in ('new_cell', 'new_wifi'):
+        score_rows[name] = session.query(
+            Score.userid, func.sum(Score.value)).filter(
+            Score.key == SCORE_TYPE[name]).filter(
+            Score.time >= one_week).order_by(
+            func.sum(Score.value).desc()).group_by(
+            Score.userid).limit(batch).all()
+        userids.update(set([s[0] for s in score_rows[name]]))
+
+    if not userids:
+        return result
+
+    user_rows = session.query(User.id, User.nickname).filter(
+        User.id.in_(userids)).all()
+    users = dict(user_rows)
+
+    for name, value in score_rows.items():
+        for userid, value in value:
+            nickname = users.get(userid, 'anonymous')
+            if len(nickname) > 24:
+                nickname = nickname[:24] + u'...'
+            result[name].append(
+                {'nickname': nickname, 'num': int(value)})
+
+    return result
+
+
 def countries(session):
     # we group by radio, mcc to take advantage of the index
     rows = session.query(Cell.radio, Cell.mcc, func.count(Cell.id)).filter(

--- a/ichnaea/content/templates/leaders.pt
+++ b/ichnaea/content/templates/leaders.pt
@@ -6,6 +6,11 @@
 <section id="main-content">
     <p>Data is updated in near-realtime.</p>
 
+    <p>
+        A <a href="/leaders/weekly">weekly leaderboard</a> showing new
+        cell and WiFi discoveries is also available.
+    </p>
+
     <div class="half-left">
         <table class="table half">
             <thead>

--- a/ichnaea/content/templates/leaders_weekly.pt
+++ b/ichnaea/content/templates/leaders_weekly.pt
@@ -1,0 +1,110 @@
+<tal:macro xmlns:tal="http://xml.zope.org/namespaces/tal"
+           xmlns:metal="http://xml.zope.org/namespaces/metal"
+           metal:use-macro="view.base_template">
+
+<tal:slot metal:fill-slot="content">
+<section id="main-content">
+    <p>Data is updated in near-realtime.</p>
+
+    <div class="separator">
+        <h3>Top 20 new cells</h3>
+
+        <p>
+            Who has discovered the most new unique cells
+            in the last seven days.
+        </p>
+
+        <div class="half-left"
+             tal:define="leaders1 scores.new_cell.leaders1">
+            <table class="table half">
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>User</th>
+                        <th class="text-right">Points</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr tal:repeat="row leaders1">
+                        <td>${row.pos}.</td>
+                        <td>${row.nickname}</td>
+                        <td class="text-right">${row.num}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="half-right"
+             tal:define="leaders2 scores.new_cell.leaders2"
+             tal:condition="leaders2">
+            <table class="table half">
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>User</th>
+                        <th class="text-right">Points</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr tal:repeat="row leaders2">
+                        <td>${row.pos}.</td>
+                        <td>${row.nickname}</td>
+                        <td class="text-right">${row.num}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="separator">
+        <h3>Top 20 new WiFi networks</h3>
+
+        <p>
+            Who has discovered the most new unique WiFi networks
+            in the last seven days.
+        </p>
+
+        <div class="half-left"
+             tal:define="leaders1 scores.new_wifi.leaders1">
+            <table class="table half">
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>User</th>
+                        <th class="text-right">Points</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr tal:repeat="row leaders1">
+                        <td>${row.pos}.</td>
+                        <td>${row.nickname}</td>
+                        <td class="text-right">${row.num}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="half-right"
+             tal:define="leaders2 scores.new_wifi.leaders2"
+             tal:condition="leaders2">
+            <table class="table half">
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>User</th>
+                        <th class="text-right">Points</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr tal:repeat="row leaders2">
+                        <td>${row.pos}.</td>
+                        <td>${row.nickname}</td>
+                        <td class="text-right">${row.num}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+</section>
+</tal:slot>
+
+</tal:macro>

--- a/ichnaea/content/tests/test_views.py
+++ b/ichnaea/content/tests/test_views.py
@@ -158,6 +158,32 @@ class TestFunctionalContentViews(AppTestCase):
             result['leaders2'],
             [{'nickname': u'0', 'num': 1, 'pos': 3}])
 
+    def test_leaders_weekly(self):
+        session = self.db_master_session
+        for i in range(3):
+            user = User(nickname=unicode(i))
+            session.add(user)
+            session.flush()
+            score1 = Score(userid=user.id, value=i)
+            score1.name = 'new_cell'
+            session.add(score1)
+            score2 = Score(userid=user.id, value=i)
+            score2.name = 'new_wifi'
+            session.add(score2)
+        session.commit()
+        request = DummyRequest()
+        request.db_slave_session = self.db_master_session
+        inst = self._make_view(request)
+        result = inst.leaders_weekly_view()
+        for score_name in ('new_cell', 'new_wifi'):
+            self.assertEqual(
+                result['scores'][score_name]['leaders1'],
+                [{'nickname': u'2', 'num': 2, 'pos': 1},
+                 {'nickname': u'1', 'num': 1, 'pos': 2}])
+            self.assertEqual(
+                result['scores'][score_name]['leaders2'],
+                [{'nickname': u'0', 'num': 0, 'pos': 3}])
+
     def test_stats(self):
         day = datetime.utcnow().date() - timedelta(1)
         session = self.db_master_session


### PR DESCRIPTION
This is a first simple step to fix #24. The top-20 limit is arbitrary and meant to cut down page size to something reasonable. Proper paging through the various leaderboards will allow us to expose the long-tail later.
