### PR TITLE
Fixes #186 to initialize ichnaea database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 
 .PHONY: all js test docs mysql
 
-all: build
+all: build init_db
 
 mysql:
 ifeq ($(TRAVIS), true)
@@ -52,6 +52,9 @@ build: $(PYTHON) mysql
 	$(INSTALL) -r requirements/prod.txt
 	$(INSTALL) -r requirements/test.txt
 	$(PYTHON) setup.py develop
+
+init_db:
+	$(BIN)/init_ichnaea_db --initdb
 
 css: node_modules
 	$(HERE)/node_modules/.bin/cleancss -d \

--- a/ichnaea/db.py
+++ b/ichnaea/db.py
@@ -1,10 +1,13 @@
+import argparse
 from contextlib import contextmanager
+import sys
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql.expression import Insert
 from sqlalchemy.orm import sessionmaker
+
 
 _Model = declarative_base()
 
@@ -91,3 +94,39 @@ class Database(object):
 
     def session(self):
         return self.session_factory()
+
+
+def main(argv, _db_master=None):
+    parser = argparse.ArgumentParser(
+        prog=argv[0], description='Initialize Ichnaea database')
+
+    parser.add_argument('--initdb', action='store_true',
+                        help='Initialize database')
+
+    args = parser.parse_args(argv[1:])
+
+    if args.initdb:
+        from ichnaea import config
+        conf = config()
+        db_master = Database(conf.get('ichnaea', 'db_master'))
+        engine = db_master.engine
+        with engine.connect() as conn:
+            trans = conn.begin()
+            _Model.metadata.create_all(engine)
+            trans.commit()
+
+            # Now stamp the latest alembic version
+            from alembic.config import Config
+            from alembic import command
+            import os
+            ini = os.environ.get('ICHNAEA_CFG', 'ichnaea.ini')
+            alembic_ini = os.path.join(os.path.split(ini)[0], 'alembic.ini')
+            alembic_cfg = Config(alembic_ini)
+            command.stamp(alembic_cfg, "head")
+            command.current(alembic_cfg)
+    else:
+        parser.print_help()
+
+
+def console_entry():  # pragma: no cover
+    main(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,6 @@ setup(
     entry_points="""\
     [console_scripts]
     location_import = ichnaea.importer:console_entry
+    init_ichnaea_db= ichnaea.db:console_entry
     """,
 )


### PR DESCRIPTION
This initializes the ichnaea database with the standard 'build' Make target and adds a separate target 'init_db' if you need to just get your database to sync to the latest model definition and stamp the database with alembic's head revision.

This should close out #186 
