### PR TITLE
Stop answering search/geolocate queries from invalid API keys, closes #231

### DIFF
--- a/docs/api/invalid_apikey.rst
+++ b/docs/api/invalid_apikey.rst
@@ -1,5 +1,5 @@
 For API key mismatches we return a `keyInvalid` message with an HTTP
-400 error.  The JSON response should be:
+400 error. The JSON response should be:
 
 .. code-block:: javascript
 
@@ -8,9 +8,9 @@ For API key mismatches we return a `keyInvalid` message with an HTTP
             "errors": [{
                 "domain": "usageLimits",
                 "reason": "keyInvalid",
-                "message": "No API key was found",
+                "message": "Missing or invalid API key.",
             }],
             "code": 400,
-            "message": "No API key",
+            "message": "Invalid API key",
         }
     }


### PR DESCRIPTION
Also use more realistic test data. The changes to the error message are ok, as the message part isn't actually specified in the API docs. It's only the code, domain and reason which are official.
