### PR TITLE
Calculate geoip accuracies from country bounding box data, closes #145.

### DIFF
--- a/ichnaea/geocalc.py
+++ b/ichnaea/geocalc.py
@@ -3,6 +3,34 @@ from country_bounding_boxes import country_subunits_by_iso_code
 
 EARTH_RADIUS = 6371  # radius of earth in km
 
+_radius_cache = {}
+
+
+def maximum_country_radius(country):
+    """
+    Return the maximum radius of a circle encompassing the largest
+    country subunit in meters, rounded to 1 km increments.
+    """
+    if not isinstance(country, str):
+        return None
+    country = country.upper()
+    if len(country) not in (2, 3):
+        return None
+
+    value = _radius_cache.get(country, None)
+    if value:
+        return value
+
+    diagonals = []
+    for c in country_subunits_by_iso_code(country):
+        (lon1, lat1, lon2, lat2) = c.bbox
+        diagonals.append(distance(lat1, lon1, lat2, lon2))
+    if diagonals:
+        # Divide by two to get radius, round to 1 km and convert to meters
+        value = _radius_cache[country] = round(max(diagonals) / 2.0) * 1000.0
+
+    return value
+
 
 def distance(lat1, lon1, lat2, lon2):
     """

--- a/ichnaea/service/search/views.py
+++ b/ichnaea/service/search/views.py
@@ -22,9 +22,10 @@ from ichnaea.service.error import (
 )
 from ichnaea.heka_logging import get_heka_client
 from ichnaea.service.search.schema import SearchSchema
+from ichnaea.geoip import radius_from_geoip
 from ichnaea.geocalc import (
     distance,
-    location_is_in_country
+    location_is_in_country,
 )
 from collections import namedtuple
 import operator
@@ -303,11 +304,10 @@ def geoip_and_best_guess_country_code(data, request, api_name):
 
     if geoip:
         # GeoIP always wins if we have it.
-        if 'city' in geoip and geoip['city']:
-            accuracy = GEOIP_CITY_ACCURACY
+        accuracy, city = radius_from_geoip(geoip)
+        if city:
             heka_client.incr('%s.geoip_city_found' % api_name)
         else:
-            accuracy = GEOIP_COUNTRY_ACCURACY
             heka_client.incr('%s.geoip_country_found' % api_name)
 
         if cell_countries and geoip['country_code'] not in cell_countries:


### PR DESCRIPTION
@rtilder, @graydon can one of you review and potentially merge this?

This should take care of returning a country specific accuracy value, continue to return a smaller city accuracy value, but also take into account small countries and return for example 1km accuracy for the Vatican.

I've opted for low-level unit tests for most of this, as we don't have a country-only entry in our test GeoIP.dat file.
