### PR TITLE
Features/312 user email digest

### DIFF
--- a/ichnaea/content/models.py
+++ b/ichnaea/content/models.py
@@ -120,7 +120,7 @@ class User(_Model):
     __tablename__ = 'user'
     __table_args__ = (
         UniqueConstraint('nickname', name='user_nickname_unique'),
-        UniqueConstraint('email', name='user_email_unique'),
+        UniqueConstraint('email_digest', name='user_email_unique'),
         {
             'mysql_engine': 'InnoDB',
             'mysql_charset': 'utf8',
@@ -129,6 +129,6 @@ class User(_Model):
     id = Column(Integer(unsigned=True),
                 primary_key=True, autoincrement=True)
     nickname = Column(Unicode(128))
-    email = Column(Unicode(128))
+    email_digest = Column(Unicode(128))
 
 user_table = User.__table__

--- a/ichnaea/service/submit/tests/test_views.py
+++ b/ichnaea/service/submit/tests/test_views.py
@@ -357,7 +357,7 @@ class TestSubmit(CeleryAppTestCase):
 
         # Expect a 40 character hexdigest
         email = 'riceroni@crankycoder.com'
-        email = hashlib.sha1(email).hexdigest()
+        email_digest = hashlib.sha1(email).hexdigest()
 
         app.post_json(
             '/v1/submit', {"items": [
@@ -371,12 +371,12 @@ class TestSubmit(CeleryAppTestCase):
                  "lon": 10.0,
                  "wifi": [{"key": "invalid"}]},
             ]},
-            headers={'X-Email': email},
+            headers={'X-Email': email_digest},
             status=204)
         session = self.db_master_session
         result = session.query(User).all()
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].email, email)
+        self.assertEqual(result[0].email_digest, email_digest)
         result = session.query(Score).all()
         self.assertEqual(len(result), 2)
         self.assertEqual(set([r.name for r in result]),
@@ -407,11 +407,11 @@ class TestSubmit(CeleryAppTestCase):
         app = self.app
 
         email = 'riceroni@crankycoder.com'
-        email = hashlib.sha1(email).hexdigest()
+        email_digest = hashlib.sha1(email).hexdigest()
 
         utcday = util.utcnow().date()
         session = self.db_master_session
-        user = User(email=email)
+        user = User(email_digest=email_digest)
         session.add(user)
         session.flush()
         session.add(Score(userid=user.id, key=SCORE_TYPE['location'], value=7))
@@ -423,11 +423,11 @@ class TestSubmit(CeleryAppTestCase):
                  "lon": 2.0,
                  "wifi": [{"key": "00AAAAAAAAAA"}]},
             ]},
-            headers={'X-Email': email},
+            headers={'X-Email': email_digest},
             status=204)
         result = session.query(User).all()
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].email, email)
+        self.assertEqual(result[0].email_digest, email_digest)
         result = session.query(Score).all()
         self.assertEqual(len(result), 2)
         self.assertEqual(set([r.name for r in result]),

--- a/ichnaea/service/submit/views.py
+++ b/ichnaea/service/submit/views.py
@@ -70,13 +70,13 @@ def submit_view(request):
 
     items = data['items']
     nickname = request.headers.get('X-Nickname', u'')
-    email = request.headers.get('X-Email', u'')
+    email_digest = request.headers.get('X-Email', u'')
 
     if isinstance(nickname, str):
         nickname = nickname.decode('utf-8', 'ignore')
 
-    if isinstance(email, str):
-        email = email.decode('utf-8', 'ignore')
+    if isinstance(email_digest, str):
+        email_digest = email_digest.decode('utf-8', 'ignore')
 
     # batch incoming data into multiple tasks, in case someone
     # manages to submit us a huge single request
@@ -87,7 +87,7 @@ def submit_view(request):
         try:
             insert_measures.apply_async(kwargs={'items': items,
                                                 'nickname': nickname,
-                                                'email': email},
+                                                'email_digest': email_digest},
                                         expires=7200)
         except ConnectionError:
             return HTTPServiceUnavailable()


### PR DESCRIPTION
This adds a new column 'email_digest' to the User field for collecting statistics and a new optional header 'X-Email' for submit to close off #312.

If the user submits a SHA1 hashed email address, we can use that to uniquely identify a User.

We _only_ store either the email address or the nickname, preferring the email address over the nickname.

The query side of this feature is covered in #313
