### PR TITLE
Add email field to User model (#312)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Changelog
 - Updated to latest versions of Chameleon, irc, Pygments, pyramid,
   translationstring and unittest2.
 
+- #312: Add email field to User model
+
 20141103125500
 **************
 

--- a/alembic/versions/2be495ecf073_add_email_to_user.py
+++ b/alembic/versions/2be495ecf073_add_email_to_user.py
@@ -1,0 +1,22 @@
+"""add email to user
+
+Revision ID: 2be495ecf073
+Revises: 48f67ea76ef7
+Create Date: 2014-11-17 20:33:16.417367
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2be495ecf073'
+down_revision = '48f67ea76ef7'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('user', sa.Column('email', sa.Unicode(255)))
+
+
+def downgrade():
+    op.drop_column('user', 'email')

--- a/ichnaea/content/models.py
+++ b/ichnaea/content/models.py
@@ -130,5 +130,6 @@ class User(_Model):
     id = Column(Integer(unsigned=True),
                 primary_key=True, autoincrement=True)
     nickname = Column(Unicode(128))
+    email = Column(Unicode(128))
 
 user_table = User.__table__

--- a/ichnaea/content/tests/test_models.py
+++ b/ichnaea/content/tests/test_models.py
@@ -111,10 +111,13 @@ class TestUser(DBTestCase):
         self.assertTrue(user.id is None)
 
     def test_fields(self):
-        user = self._make_one(nickname=u"World Traveler")
+        nickname = u'World Tr\xc3\xa4veler'
+        email = u'world_tr\xc3\xa4veler@email.com'
+        user = self._make_one(nickname=nickname, email=email)
         session = self.db_master_session
         session.add(user)
         session.commit()
 
         result = session.query(user.__class__).first()
-        self.assertEqual(result.nickname, u"World Traveler")
+        self.assertEqual(result.nickname, nickname)
+        self.assertEqual(result.email, email)

--- a/ichnaea/service/submit/views.py
+++ b/ichnaea/service/submit/views.py
@@ -80,6 +80,11 @@ def submit_view(request):
     nickname = request.headers.get('X-Nickname', u'')
     if isinstance(nickname, str):
         nickname = nickname.decode('utf-8', 'ignore')
+
+    email = request.headers.get('X-Email', u'')
+    if isinstance(email, str):
+        email = email.decode('utf-8', 'ignore')
+
     # batch incoming data into multiple tasks, in case someone
     # manages to submit us a huge single request
     for i in range(0, len(items), 100):
@@ -88,7 +93,11 @@ def submit_view(request):
         # after six hours to avoid queue overload
         try:
             insert_measures.apply_async(
-                kwargs={'items': batch, 'nickname': nickname},
+                kwargs={
+                    'email': email,
+                    'items': batch,
+                    'nickname': nickname,
+                },
                 expires=21600)
         except ConnectionError:  # pragma: no cover
             return HTTPServiceUnavailable()


### PR DESCRIPTION
- Add an email column (to model, not unique, migration)
- Populate email with 'X-Email' header at submission time
- Update tasks to handle
- Always expect a nickname, optionally populate email in user object in process_user
- If email addresses don't match for existing user, update email
- Add tests

@hannosch 
