### PR TITLE
Fall back to GeoIP for incomplete search requests, closes #343.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Migrations
 Changes
 ~~~~~~~
 
+- #343: Fall back to GeoIP for incomplete search requests.
+
 - #349/#350: Move cell areas into new table.
 
 - Give all celery queues a prefix to better distinguish them in Redis.

--- a/ichnaea/service/error.py
+++ b/ichnaea/service/error.py
@@ -12,7 +12,6 @@ from ichnaea.customjson import (
 
 MSG_EMPTY = 'No JSON body was provided.'
 MSG_GZIP = 'Error decompressing gzip data stream.'
-MSG_ONE_OF = 'You need to provide a mapping with least one cell or wifi entry.'
 MSG_BAD_RADIO = 'Radio fields were not consistent in the cellTower data.'
 
 

--- a/ichnaea/service/geolocate/tests.py
+++ b/ichnaea/service/geolocate/tests.py
@@ -191,6 +191,17 @@ class TestGeolocate(AppTestCase):
                                                  "lng": -121.96},
                                     "accuracy": GEOIP_CITY_ACCURACY})
 
+    def test_incomplete_request_means_geoip(self):
+        app = self.app
+        res = app.post_json(
+            '%s?key=test' % self.url, {"wifiAccessPoints": []},
+            extra_environ={'HTTP_X_FORWARDED_FOR': FREMONT_IP},
+            status=200)
+        self.assertEqual(res.content_type, 'application/json')
+        self.assertEqual(res.json, {"location": {"lat": 37.5079,
+                                                 "lng": -121.96},
+                                    "accuracy": GEOIP_CITY_ACCURACY})
+
     def test_parse_error(self):
         app = self.app
         res = app.post_json(
@@ -215,13 +226,6 @@ class TestGeolocate(AppTestCase):
         self.check_stats(
             counter=[self.metric + '.api_key.test']
         )
-
-    def test_no_data(self):
-        app = self.app
-        res = app.post_json(
-            '%s?key=test' % self.url, {"wifiAccessPoints": []},
-            status=400)
-        self.assertEqual(res.content_type, 'application/json')
 
     def test_no_api_key(self):
         app = self.app

--- a/ichnaea/service/geolocate/views.py
+++ b/ichnaea/service/geolocate/views.py
@@ -4,7 +4,6 @@ from ichnaea.customjson import dumps
 from ichnaea.service.geolocate.schema import GeoLocateSchema
 from ichnaea.service.error import (
     JSONParseError,
-    MSG_ONE_OF,
     preprocess_request,
 )
 from ichnaea.service.base import check_api_key
@@ -33,24 +32,12 @@ def configure_geolocate(config):
     config.add_view(geolocate_view, route_name='v1_geolocate', renderer='json')
 
 
-def geolocate_validator(data, errors):
-    if errors:
-        # don't add this error if something else was already wrong
-        return
-    cell = data.get('cellTowers', ())
-    wifi = data.get('wifiAccessPoints', ())
-
-    if not any(wifi) and not any(cell):
-        errors.append(dict(name='body', description=MSG_ONE_OF))
-
-
 @check_api_key('geolocate')
 def geolocate_view(request):
 
     data, errors = preprocess_request(
         request,
         schema=GeoLocateSchema(),
-        extra_checks=(geolocate_validator, ),
         response=JSONParseError,
         accept_empty=True,
     )

--- a/ichnaea/service/geosubmit/views.py
+++ b/ichnaea/service/geosubmit/views.py
@@ -15,15 +15,11 @@ from ichnaea.logging import get_stats_client
 from ichnaea.service.base import check_api_key
 from ichnaea.service.error import (
     JSONParseError,
-    MSG_ONE_OF,
     preprocess_request,
     verify_schema,
 )
 from ichnaea.service.geolocate.schema import GeoLocateSchema
-from ichnaea.service.geolocate.views import (
-    NOT_FOUND,
-    geolocate_validator,
-)
+from ichnaea.service.geolocate.views import NOT_FOUND
 from ichnaea.service.geosubmit.schema import (
     GeoSubmitBatchSchema,
     GeoSubmitSchema,
@@ -35,22 +31,6 @@ from ichnaea.service.locate import (
 from ichnaea.service.submit.schema import SubmitSchema
 
 SENTINEL = object()
-
-
-def geosubmit_validator(data, errors):
-    if errors:
-        # don't add this error if something else was already wrong
-        return
-    if 'items' in data:
-        chunk_list = data['items']
-    else:
-        chunk_list = [data]
-    for chunk in chunk_list:
-        cell = chunk.get('cellTowers', ())
-        wifi = chunk.get('wifiAccessPoints', ())
-
-        if not any(wifi) and not any(cell):
-            errors.append(dict(name='body', description=MSG_ONE_OF))
 
 
 def process_upload(nickname, email, items):
@@ -159,7 +139,6 @@ def geosubmit_view(request):
     data, errors = preprocess_request(
         request,
         schema=GeoSubmitBatchSchema(),
-        extra_checks=(geosubmit_validator,),
         response=None,
     )
 
@@ -193,7 +172,6 @@ def process_single(request):
     locate_data, locate_errors = preprocess_request(
         request,
         schema=GeoLocateSchema(),
-        extra_checks=(geolocate_validator, ),
         response=JSONParseError,
         accept_empty=True,
     )
@@ -201,7 +179,6 @@ def process_single(request):
     data, errors = preprocess_request(
         request,
         schema=GeoSubmitSchema(),
-        extra_checks=(geosubmit_validator,),
         response=None,
     )
     data = {'items': [data]}

--- a/ichnaea/service/search/tests/test_views.py
+++ b/ichnaea/service/search/tests/test_views.py
@@ -183,22 +183,22 @@ class TestSearch(AppTestCase):
 
     def test_error(self):
         app = self.app
-        res = app.post_json('/v1/search?key=test', {"cell": []}, status=400)
+        res = app.post_json('/v1/search?key=test', {"cell": 1}, status=400)
         self.assertEqual(res.content_type, 'application/json')
         self.assertTrue('errors' in res.json)
         self.assertFalse('status' in res.json)
 
     def test_error_unknown_key(self):
         app = self.app
-        res = app.post_json('/v1/search?key=test', {"foo": 0}, status=400)
+        res = app.post_json('/v1/search?key=test', {"foo": 0}, status=200)
         self.assertEqual(res.content_type, 'application/json')
-        self.assertTrue('errors' in res.json)
+        self.assertEqual(res.json, {"status": "not_found"})
 
     def test_error_no_mapping(self):
         app = self.app
-        res = app.post_json('/v1/search?key=test', [1], status=400)
+        res = app.post_json('/v1/search?key=test', [1], status=200)
         self.assertEqual(res.content_type, 'application/json')
-        self.assertTrue('errors' in res.json)
+        self.assertEqual(res.json, {"status": "not_found"})
 
     def test_no_valid_keys(self):
         app = self.app

--- a/ichnaea/service/search/views.py
+++ b/ichnaea/service/search/views.py
@@ -1,9 +1,6 @@
 from ichnaea.service.base import check_api_key
+from ichnaea.service.error import preprocess_request
 from ichnaea.service.locate import search_all_sources
-from ichnaea.service.error import (
-    MSG_ONE_OF,
-    preprocess_request,
-)
 from ichnaea.service.search.schema import SearchSchema
 
 
@@ -12,23 +9,11 @@ def configure_search(config):
     config.add_view(search_view, route_name='v1_search', renderer='json')
 
 
-def check_cell_or_wifi(data, errors):
-    if errors:  # pragma: no cover
-        # don't add this error if something else was already wrong
-        return
-
-    cell = data.get('cell', ())
-    wifi = data.get('wifi', ())
-    if not any(wifi) and not any(cell):
-        errors.append(dict(name='body', description=MSG_ONE_OF))
-
-
 @check_api_key('search')
 def search_view(request):
     data, errors = preprocess_request(
         request,
         schema=SearchSchema(),
-        extra_checks=(check_cell_or_wifi, ),
         accept_empty=True,
     )
 

--- a/ichnaea/service/submit/views.py
+++ b/ichnaea/service/submit/views.py
@@ -57,10 +57,6 @@ def submit_validator(data, errors):
     for idx in skips:
         del data['items'][idx]
 
-    if errors:
-        # don't add this error if something else was already wrong
-        return
-
 
 @check_api_key('submit', error_on_invalidkey=False)
 def submit_view(request):


### PR DESCRIPTION
Historically we had rather strict requirements for well-formed requests, lowering these requirements over time. As one of the last changes we allowed the exact payload of `{}` as a valid request to mean "give me a GeoIP result". As the bug says, Firefox doesn't actually send an empty mapping, but instead `{"wifiAccessPoints": []}`. Instead of special casing this again, I've just dropped the "you need to send one cell or wifi" validator, which means most malformed or empty requests will return GeoIP results now.

The change in ichnaea/service/submit/views.py / submit_validator is a drive-by fix, removing a block that didn't actually do anything.

@jaredkerim r?
