### PR TITLE
Add a new `__monitor__` endpoint, refs #274.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Migrations
 Changes
 ~~~~~~~
 
+- #274: Add a new `__monitor__` endpoint.
+
 - #311: On station creation optionally use previous blacklist time.
 
 - #378: Use colander for internal data validation.

--- a/ichnaea/cache.py
+++ b/ichnaea/cache.py
@@ -1,5 +1,20 @@
-import redis
 import urlparse
+
+import redis
+from redis.exceptions import ConnectionError
+
+
+class RedisClient(redis.StrictRedis):
+
+    def ping(self):
+        """
+        Ping the Redis server, but also catch exceptions.
+        """
+        try:
+            self.execute_command('PING')
+        except ConnectionError:
+            return False
+        return True
 
 
 def redis_client(redis_url):
@@ -23,4 +38,4 @@ def redis_client(redis_url):
         socket_connect_timeout=30.0,
         socket_keepalive=True,
     )
-    return redis.StrictRedis(connection_pool=pool)
+    return RedisClient(connection_pool=pool)

--- a/ichnaea/service/__init__.py
+++ b/ichnaea/service/__init__.py
@@ -3,6 +3,7 @@ def configure_service(config):
     from ichnaea.service.geolocate.views import configure_geolocate
     from ichnaea.service.geosubmit.views import configure_geosubmit
     from ichnaea.service.heartbeat.views import configure_heartbeat
+    from ichnaea.service.monitor.views import configure_monitor
     from ichnaea.service.search.views import configure_search
     from ichnaea.service.submit.views import configure_submit
 
@@ -10,5 +11,6 @@ def configure_service(config):
     configure_geolocate(config)
     configure_geosubmit(config)
     configure_heartbeat(config)
+    configure_monitor(config)
     configure_search(config)
     configure_submit(config)

--- a/ichnaea/service/monitor/tests.py
+++ b/ichnaea/service/monitor/tests.py
@@ -1,0 +1,63 @@
+from ichnaea.logging import PingableStatsClient
+from ichnaea.tests.base import (
+    _make_db,
+    _make_redis,
+    AppTestCase,
+)
+
+
+class TestMonitor(AppTestCase):
+
+    def test_ok(self):
+        app = self.app
+        response = app.get('/__monitor__', status=200)
+        self.assertEqual(response.content_type, 'application/json')
+        data = response.json
+        timed_services = set(['database', 'redis', 'stats'])
+        self.assertEqual(set(data.keys()), timed_services)
+
+        for name in timed_services:
+            self.assertEqual(data[name]['up'], True)
+            self.assertTrue(isinstance(data[name]['time'], int))
+            self.assertTrue(data[name]['time'] >= 0)
+
+
+class TestMonitorErrors(AppTestCase):
+
+    def setUp(self):
+        super(TestMonitorErrors, self).setUp()
+        # create database connections to the discard port
+        db_uri = 'mysql+pymysql://none:none@127.0.0.1:9/none'
+        self.broken_db = _make_db(uri=db_uri)
+        self.app.app.registry.db_master = self.broken_db
+        self.app.app.registry.db_slave = self.broken_db
+        # create broken redis connection
+        redis_uri = 'redis://127.0.0.1:9/15'
+        self.broken_redis = _make_redis(redis_uri)
+        self.app.app.registry.redis_client = self.broken_redis
+        # create broken stats client
+        self.broken_stats = PingableStatsClient(host='127.0.0.1', port=0)
+        self.app.app.registry.stats_client = self.broken_stats
+
+    def tearDown(self):
+        super(TestMonitorErrors, self).tearDown()
+        self.broken_db.engine.pool.dispose()
+        del self.broken_db
+        self.broken_redis.connection_pool.disconnect()
+        del self.broken_redis
+        del self.broken_stats
+
+    def test_database_error(self):
+        res = self.app.get('/__monitor__', status=200)
+        self.assertEqual(res.content_type, 'application/json')
+        self.assertEqual(res.json['database'], {'up': False, 'time': 0})
+
+    def test_redis_error(self):
+        res = self.app.get('/__monitor__', status=200)
+        self.assertEqual(res.content_type, 'application/json')
+        self.assertEqual(res.json['redis'], {'up': False, 'time': 0})
+
+    def test_stats_error(self):
+        res = self.app.get('/__monitor__', status=200)
+        self.assertEqual(res.content_type, 'application/json')
+        self.assertEqual(res.json['stats'], {'up': False, 'time': 0})

--- a/ichnaea/service/monitor/views.py
+++ b/ichnaea/service/monitor/views.py
@@ -1,0 +1,64 @@
+import time
+
+from pyramid.view import view_config
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.sql import func, select
+
+
+def configure_monitor(config):
+    config.scan('ichnaea.service.monitor.views')
+
+
+class Timer(object):
+
+    def __init__(self):
+        self.start = None
+        self.ms = None
+
+    def __enter__(self):
+        self.start = time.time()
+        return self
+
+    def __exit__(self, typ, value, tb):
+        if self.start is not None:
+            dt = time.time() - self.start
+            self.ms = int(round(1000 * dt))
+
+
+def _check_timed(ping_function):
+    with Timer() as timer:
+        success = ping_function()
+    if not success:
+        return {'up': False, 'time': 0}
+    return {'up': True, 'time': timer.ms}
+
+
+def check_database(request):
+    return _check_timed(request.db_slave_session.ping)
+
+
+def check_redis(request):
+    return _check_timed(request.registry.redis_client.ping)
+
+
+def check_stats(request):
+    return _check_timed(request.registry.stats_client.ping)
+
+
+@view_config(renderer='json', name="__monitor__")
+def monitor_view(request):
+    services = {
+        'database': check_database,
+        'redis': check_redis,
+        'stats': check_stats,
+    }
+    result = {}
+    for name, check in services.items():
+        try:
+            service_result = check(request)
+        except Exception:  # pragma: no cover
+            result[name] = {'up': False}
+        else:
+            result[name] = service_result
+
+    return result


### PR DESCRIPTION
This adds basic monitoring output for the database, redis (cache) and statsd connections.

Test and see if the discard port is configured the same way on travis-ci.