### PR TITLE
Update raven to latest version, requires a Sentry 7 server.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Migrations
 Changes
 ~~~~~~~
 
+- Updated to latest raven version, requires a Sentry 7 server.
+
 - Updated to latests versions of billiard, pyramid and WebOb.
 
 20150416111700

--- a/compile.py
+++ b/compile.py
@@ -20,6 +20,7 @@ import sys
 
 EXCLUDES_27 = [
     'linecache2/tests/inspect_fodder2.py',
+    'raven/transport/aiohttp.py',
 ]
 EXCLUDES_34 = [
     'gunicorn/workers/_gaiohttp.py',

--- a/compile.py
+++ b/compile.py
@@ -20,10 +20,10 @@ import sys
 
 EXCLUDES_27 = [
     'linecache2/tests/inspect_fodder2.py',
-    'raven/transport/aiohttp.py',
 ]
 EXCLUDES_34 = [
     'gunicorn/workers/_gaiohttp.py',
+    'raven/transport/aiohttp.py',
 ]
 
 

--- a/ichnaea.ini
+++ b/ichnaea.ini
@@ -12,7 +12,7 @@ s3_assets_bucket =
 assets_url = http://localhost:7001/static/
 
 statsd_host = localhost:8125
-sentry_dsn = udp://username:password@localhost:9001/2
+sentry_dsn = http://username:password@localhost:9/1
 
 # Note: this URL has to end with a trailing slash, "http://.../downloads/"
 ocid_url = http://localhost:7001/downloads/

--- a/ichnaea/async/config.py
+++ b/ichnaea/async/config.py
@@ -95,7 +95,8 @@ def init_worker(celery_app, app_config,
         app_config.get('ichnaea', 'db_master'), _db=_db_rw)
 
     celery_app.raven_client = configure_raven(
-        app_config.get('ichnaea', 'sentry_dsn'), _client=_raven_client)
+        app_config.get('ichnaea', 'sentry_dsn'),
+        transport='threaded', _client=_raven_client)
 
     celery_app.redis_client = configure_redis(
         app_config.get('ichnaea', 'redis_url'), _client=_redis_client)

--- a/ichnaea/log.py
+++ b/ichnaea/log.py
@@ -26,9 +26,14 @@ def set_raven_client(client):
     return RAVEN_CLIENT
 
 
-def configure_raven(config, _client=None):  # pragma: no cover
+def configure_raven(config, transport='sync',
+                    _client=None):  # pragma: no cover
     if _client is not None:
         return set_raven_client(_client)
+
+    if config and '+' not in config.split(':')[0]:
+        # no explicit transport was specified in the dsn
+        config = '%s+%s' % (transport, config)
 
     client = RavenClient(dsn=config)
     return set_raven_client(client)

--- a/ichnaea/tests/base.py
+++ b/ichnaea/tests/base.py
@@ -333,8 +333,8 @@ class LogIsolation(object):
     @classmethod
     def setup_logging(cls):
         # Use a debug configuration
-        cls.raven_client = configure_raven('', DebugRavenClient())
-        cls.stats_client = configure_stats('', DebugStatsClient())
+        cls.raven_client = configure_raven('', _client=DebugRavenClient())
+        cls.stats_client = configure_stats('', _client=DebugStatsClient())
 
     @classmethod
     def teardown_logging(cls):

--- a/ichnaea/webapp/config.py
+++ b/ichnaea/webapp/config.py
@@ -42,7 +42,8 @@ def main(global_config, app_config, init=False,
         app_config.get('ichnaea', 'db_slave'), _db=_db_ro)
 
     registry.raven_client = raven_client = configure_raven(
-        app_config.get('ichnaea', 'sentry_dsn'), _client=_raven_client)
+        app_config.get('ichnaea', 'sentry_dsn'),
+        transport='gevent', _client=_raven_client)
 
     registry.redis_client = configure_redis(
         app_config.get('ichnaea', 'redis_url'), _client=_redis_client)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,6 +9,7 @@ anyjson==0.3.3
 argparse==1.3.0
 boto==2.38.0
 celery==3.1.17
+certifi==14.05.14
 colander==1.0
 configparser==3.5.0b2
 country-bounding-boxes==0.2.2
@@ -27,7 +28,7 @@ ordereddict==1.1
 pyramid==1.5.6
 pyramid-chameleon==0.3
 pytz==2015.2
-raven==3.4.1  # rq.filter: <3.5.0
+raven==5.2.0
 redis==2.10.3
 repoze.lru==0.6
 requests==2.6.0


### PR DESCRIPTION
This manages the transport manually, using gevent for webapp, threaded for celery and sync for scripts and tests.

We also pull in certifi, as it's automatically used internally by raven when using a https transport.

This is waiting on ops changes.