### PR TITLE
Cache single cell results for fallback #421

### DIFF
--- a/ichnaea.ini
+++ b/ichnaea.ini
@@ -35,5 +35,6 @@ batch = 10
 
 [locate:fallback]
 url = http://127.0.0.1:9?api
-ratelimit = 
-cache_timeout = 
+ratelimit =
+ratelimit_expire =
+cache_expire =

--- a/ichnaea/service/search/tests.py
+++ b/ichnaea/service/search/tests.py
@@ -1,4 +1,3 @@
-import mock
 import requests_mock
 from pyramid.testing import DummyRequest
 from sqlalchemy import text

--- a/ichnaea/tests/base.py
+++ b/ichnaea/tests/base.py
@@ -77,6 +77,8 @@ TEST_CONFIG = DummyConfig({
     'locate:fallback': {
         'url': 'http://127.0.0.1:9/?api',
         'ratelimit': '10',
+        'ratelimit_expire': '60',
+        'cache_expire': '60',
     },
 })
 


### PR DESCRIPTION
- When we receive only a single cell tower, cache the results
- Add tests

@hannosch r?