### PR TITLE
Add explicit fallback choices to geolocate API #438

### DIFF
--- a/ichnaea/locate/location.py
+++ b/ichnaea/locate/location.py
@@ -5,16 +5,17 @@ from ichnaea.geocalc import distance
 class Location(object):
     """A location returned by a location provider."""
 
-    def __init__(self, source=None,
-                 lat=None, lon=None, accuracy=None,
-                 country_code=None, country_name=None, query_data=True):
-        self.source = source
-        self.lat = self._round(lat)
-        self.lon = self._round(lon)
+    def __init__(self, accuracy=None, country_code=None, country_name=None,
+                 fallback=None, lat=None, lon=None, query_data=True,
+                 source=None):
         self.accuracy = self._round(accuracy)
         self.country_code = country_code
         self.country_name = country_name
+        self.fallback = fallback
+        self.lat = self._round(lat)
+        self.lon = self._round(lon)
         self.query_data = query_data
+        self.source = source
 
     def _round(self, value):
         if value is not None:

--- a/ichnaea/locate/searcher.py
+++ b/ichnaea/locate/searcher.py
@@ -104,7 +104,6 @@ class Searcher(StatsLogger):
         location = self._search(data)
         if location.found():
             return self._prepare(location)
-        return None
 
 
 class PositionSearcher(Searcher):
@@ -136,6 +135,7 @@ class PositionSearcher(Searcher):
             'lat': location.lat,
             'lon': location.lon,
             'accuracy': location.accuracy,
+            'fallback': location.fallback,
         }
 
 

--- a/ichnaea/locate/tests/test_searcher.py
+++ b/ichnaea/locate/tests/test_searcher.py
@@ -45,6 +45,8 @@ class SearcherTest(ConnectionTestCase):
                 def _prepare(self, location):
                     return location
 
+        data = data or {}
+
         return TestSearcher(
             session_db=self.session,
             geoip_db=self.geoip_db,
@@ -289,6 +291,7 @@ class TestPositionSearcher(SearcherTest):
         class TestProvider(Provider):
             location_type = TestLocation
             log_name = 'test'
+            fallback_field = 'fallback'
 
             def locate(self, data):
                 return self.location_type(lat=1.0, lon=1.0, accuracy=1000)
@@ -302,6 +305,7 @@ class TestPositionSearcher(SearcherTest):
         self.assertEqual(location['lat'], 1.0)
         self.assertEqual(location['lon'], 1.0)
         self.assertEqual(location['accuracy'], 1000)
+        self.assertEqual(location['fallback'], 'fallback')
 
 
 class TestCountrySearcher(SearcherTest):

--- a/ichnaea/service/base_locate.py
+++ b/ichnaea/service/base_locate.py
@@ -69,9 +69,12 @@ class BaseLocateView(BaseAPIView):
         transform = self.transform()
         parsed_data = transform.transform_one(request_data)
 
-        query = {'geoip': self.request.client_addr}
-        query['cell'] = parsed_data.get('cell', [])
-        query['wifi'] = parsed_data.get('wifi', [])
+        query = {
+            'geoip': self.request.client_addr,
+            'cell': parsed_data.get('cell', []),
+            'wifi': parsed_data.get('wifi', []),
+            'fallbacks': request_data.get('fallbacks', {}),
+        }
         return query
 
     def locate(self, api_key):

--- a/ichnaea/service/geolocate/schema.py
+++ b/ichnaea/service/geolocate/schema.py
@@ -10,6 +10,8 @@ from colander import (
     String,
 )
 
+from ichnaea.service.schema import FallbackSchema
+
 RADIO_STRINGS = ['gsm', 'cdma', 'wcdma', 'lte']
 
 
@@ -62,3 +64,4 @@ class GeoLocateSchema(MappingSchema):
 
     cellTowers = CellTowersSchema(missing=())
     wifiAccessPoints = WifiAccessPointsSchema(missing=())
+    fallbacks = FallbackSchema(missing=None)

--- a/ichnaea/service/schema.py
+++ b/ichnaea/service/schema.py
@@ -4,6 +4,8 @@ import time
 
 import colander
 import iso8601
+from colander import MappingSchema, SchemaNode
+from colander import Boolean
 
 
 class BoundedFloat(colander.Float):
@@ -87,3 +89,9 @@ class OptionalIntNode(OptionalNode):
 class OptionalStringNode(OptionalNode):
 
     schema_type = colander.String
+
+
+class FallbackSchema(MappingSchema):
+
+    lacf = SchemaNode(Boolean(), missing=True)
+    ipf = SchemaNode(Boolean(), missing=True)

--- a/ichnaea/service/search/schema.py
+++ b/ichnaea/service/search/schema.py
@@ -1,6 +1,9 @@
 from colander import MappingSchema, SchemaNode, SequenceSchema
 from colander import Integer, String, OneOf
 
+from ichnaea.service.schema import FallbackSchema
+
+
 RADIO_STRINGS = ['gsm', 'cdma', 'umts', 'wcdma', 'lte']
 
 
@@ -44,3 +47,4 @@ class SearchSchema(MappingSchema):
                        validator=OneOf(RADIO_STRINGS), missing=None)
     cell = CellsSchema(missing=())
     wifi = WifisSchema(missing=())
+    fallbacks = FallbackSchema(missing=None)

--- a/ichnaea/service/search/views.py
+++ b/ichnaea/service/search/views.py
@@ -41,13 +41,18 @@ class SearchView(BaseLocateView):
         return {'status': 'not_found'}
 
     def view(self, api_key):
-        result = self.locate(api_key)
-        if not result:
+        location_data = self.locate(api_key)
+        if not location_data:
             return self.not_found()
 
-        return {
+        response = {
             'status': 'ok',
-            'lat': result['lat'],
-            'lon': result['lon'],
-            'accuracy': result['accuracy'],
+            'lat': location_data['lat'],
+            'lon': location_data['lon'],
+            'accuracy': location_data['accuracy'],
         }
+
+        if location_data['fallback']:
+            response['fallback'] = location_data['fallback']
+
+        return response


### PR DESCRIPTION
- Accept lacf/ipf flags in search api
- Accept lacf/ipf flags in search providers
- Pass lacf/ipf flags to fallback provider
- Add tests