### PR TITLE
Allow v1/v2 API queries without CID #440

### DIFF
--- a/ichnaea/locate/provider.py
+++ b/ichnaea/locate/provider.py
@@ -20,6 +20,7 @@ from ichnaea.models import (
     Cell,
     CellArea,
     CellLookup,
+    CellAreaLookup,
     OCIDCell,
     OCIDCellArea,
     Wifi,
@@ -144,14 +145,15 @@ class BaseCellProvider(Provider):
     model = None
     log_name = 'cell'
     location_type = Position
+    validator = CellLookup
 
     def _clean_cell_keys(self, data):
         """Pre-process cell data."""
         cell_keys = []
         for cell in data.get('cell', ()):
-            cell = CellLookup.validate(cell)
+            cell = self.validator.validate(cell)
             if cell:
-                cell_key = CellLookup.to_hashkey(cell)
+                cell_key = self.validator.to_hashkey(cell)
                 cell_keys.append(cell_key)
 
         return cell_keys
@@ -234,7 +236,7 @@ class CellPositionProvider(BaseCellProvider):
     model = Cell
 
 
-class OCIDCellPositionProvider(CellPositionProvider):
+class OCIDCellPositionProvider(BaseCellProvider):
     """
     A OCIDCellPositionProvider implements a cell search using
     the OCID Cell model.
@@ -250,6 +252,7 @@ class CellAreaPositionProvider(BaseCellProvider):
     """
     model = CellArea
     log_name = 'cell_lac'
+    validator = CellAreaLookup
 
     def _prepare(self, queried_cells):
         # take the smallest LAC of any the user is inside

--- a/ichnaea/models/__init__.py
+++ b/ichnaea/models/__init__.py
@@ -26,6 +26,7 @@ from ichnaea.models.content import (  # NOQA
 )
 from ichnaea.models.observation import (  # NOQA
     CellLookup,
+    CellAreaLookup,
     CellObservation,
     CellReport,
     Report,

--- a/ichnaea/models/observation.py
+++ b/ichnaea/models/observation.py
@@ -26,6 +26,7 @@ from ichnaea.models.cell import (
     CellKeyPsc,
     CellKeyPscMixin,
     ValidCellKeySchema,
+    ValidCellAreaKeySchema,
 )
 from ichnaea.models import constants
 from ichnaea.models.base import ValidPositionSchema
@@ -157,14 +158,19 @@ class ValidCellLookupSchema(ValidCellKeySchema):
         return super(ValidCellLookupSchema, self).deserialize(data)
 
 
-class CellLookup(CellKeyPscMixin, ValidationMixin):
+class CellAreaLookup(CellKeyPscMixin, ValidationMixin):
 
     _hashkey_cls = CellKey
-    _valid_schema = ValidCellLookupSchema
+    _valid_schema = ValidCellAreaKeySchema
 
     asu = Column(SmallInteger)
     signal = Column(SmallInteger)
     ta = Column(TinyInteger)
+
+
+class CellLookup(CellAreaLookup):
+
+    _valid_schema = ValidCellLookupSchema
 
 
 class ValidCellReportSchema(ValidCellLookupSchema):


### PR DESCRIPTION
- Create CellAreaLookup and ValidCellAreaKeySchema
- Abstract out schema validator from Cell providers
- Add tests to v1 and v2 APIs