### PR TITLE
Replace LocateTransform with an internal class based representation #444

### DIFF
--- a/ichnaea/api/locate/country/views.py
+++ b/ichnaea/api/locate/country/views.py
@@ -1,8 +1,8 @@
 from ichnaea.api.locate.searcher import CountrySearcher
-from ichnaea.api.locate.views import BaseLocateView
+from ichnaea.api.locate.locate_v2.views import LocateV2View
 
 
-class CountryView(BaseLocateView):
+class CountryView(LocateV2View):
 
     # TODO: Disable API key checks and logging, for the initial wave
     check_api_key = False
@@ -11,9 +11,5 @@ class CountryView(BaseLocateView):
     route = '/v1/country'
     view_name = 'country'
 
-    def view(self, api_key):
-        result = self.locate(api_key)
-        if not result:
-            return self.not_found()
-
-        return result
+    def prepare_location_data(self, location_data):
+        return location_data

--- a/ichnaea/api/locate/locate_v1/schema.py
+++ b/ichnaea/api/locate/locate_v1/schema.py
@@ -1,13 +1,19 @@
 from colander import MappingSchema, SchemaNode, SequenceSchema
 from colander import Integer, String, OneOf
 
-from ichnaea.api.schema import FallbackSchema
+from ichnaea.api.schema import (
+    FallbackSchema,
+    InternalMapping,
+    InternalSchemaNode,
+)
+from ichnaea.api.locate.schema import BaseLocateSchema
 
 
 RADIO_STRINGS = ['gsm', 'cdma', 'umts', 'wcdma', 'lte']
 
 
 class CellSchema(MappingSchema):
+    schema_type = InternalMapping
 
     radio = SchemaNode(String(),
                        validator=OneOf(RADIO_STRINGS), missing=None)
@@ -28,12 +34,14 @@ class CellsSchema(SequenceSchema):
 
 
 class WifiSchema(MappingSchema):
+    schema_type = InternalMapping
 
     key = SchemaNode(String(), missing=None)
     frequency = SchemaNode(Integer(), missing=None)
     channel = SchemaNode(Integer(), missing=None)
     signal = SchemaNode(Integer(), missing=None)
-    signalToNoiseRatio = SchemaNode(Integer(), missing=None)
+    signalToNoiseRatio = InternalSchemaNode(
+        Integer(), missing=None, internal_name='snr')
 
 
 class WifisSchema(SequenceSchema):
@@ -41,7 +49,7 @@ class WifisSchema(SequenceSchema):
     wifi = WifiSchema()
 
 
-class LocateV1Schema(MappingSchema):
+class LocateV1Schema(BaseLocateSchema):
 
     radio = SchemaNode(String(),
                        validator=OneOf(RADIO_STRINGS), missing=None)

--- a/ichnaea/api/locate/locate_v1/views.py
+++ b/ichnaea/api/locate/locate_v1/views.py
@@ -1,32 +1,6 @@
 from ichnaea.api.error import JSONError
 from ichnaea.api.locate.locate_v1.schema import LocateV1Schema
 from ichnaea.api.locate.views import BaseLocateView
-from ichnaea.models.transform import ReportTransform
-
-
-class LocateV1Transform(ReportTransform):
-
-    radio_id = ('radio', 'radio')
-    cell_id = ('cell', 'cell')
-    cell_map = [
-        'radio',
-        'mcc',
-        'mnc',
-        'lac',
-        'cid',
-        'signal',
-        'ta',
-        'psc',
-    ]
-
-    wifi_id = ('wifi', 'wifi')
-    wifi_map = [
-        'key',
-        'channel',
-        'frequency',
-        'signal',
-        ('signalToNoiseRatio', 'snr'),
-    ]
 
 
 class LocateV1View(BaseLocateView):
@@ -34,17 +8,12 @@ class LocateV1View(BaseLocateView):
     error_response = JSONError
     route = '/v1/search'
     schema = LocateV1Schema
-    transform = LocateV1Transform
     view_name = 'search'
 
     def not_found(self):
         return {'status': 'not_found'}
 
-    def view(self, api_key):
-        location_data = self.locate(api_key)
-        if not location_data:
-            return self.not_found()
-
+    def prepare_location_data(self, location_data):
         response = {
             'status': 'ok',
             'lat': location_data['lat'],

--- a/ichnaea/api/locate/locate_v2/schema.py
+++ b/ichnaea/api/locate/locate_v2/schema.py
@@ -10,58 +10,79 @@ from colander import (
     String,
 )
 
-from ichnaea.api.schema import FallbackSchema
+from ichnaea.api.schema import (
+    FallbackSchema,
+    InternalMapping,
+    InternalMixin,
+    InternalSchemaNode,
+)
+from ichnaea.api.locate.schema import BaseLocateSchema
 
 RADIO_STRINGS = ['gsm', 'cdma', 'wcdma', 'lte']
 
 
 class CellTowerSchema(MappingSchema):
+    schema_type = InternalMapping
 
     # radio is a FxOS specific undocumented workaround
-    radio = SchemaNode(String(),
-                       validator=OneOf(RADIO_STRINGS), missing=None)
-    radioType = SchemaNode(String(),
-                           validator=OneOf(RADIO_STRINGS), missing=None)
-    mobileCountryCode = SchemaNode(Integer(), missing=None)
-    mobileNetworkCode = SchemaNode(Integer(), missing=None)
-    locationAreaCode = SchemaNode(Integer(), missing=None)
-    cellId = SchemaNode(Integer(), missing=None)
+    radio = SchemaNode(String(), validator=OneOf(RADIO_STRINGS), missing=None)
+    # radioType resolves to the internal field 'radio', so if both 'radio' and
+    # 'radioType' are provided, radioType should take precedence.  colander
+    # respects the order that fields are defined and so radioType is defined
+    # after the 'radio' field.
+    radioType = InternalSchemaNode(
+        String(), validator=OneOf(RADIO_STRINGS),
+        missing=None, internal_name='radio')
+    mobileCountryCode = InternalSchemaNode(
+        Integer(), missing=None, internal_name='mcc')
+    mobileNetworkCode = InternalSchemaNode(
+        Integer(), missing=None, internal_name='mnc')
+    locationAreaCode = InternalSchemaNode(
+        Integer(), missing=None, internal_name='lac')
+    cellId = InternalSchemaNode(
+        Integer(), missing=None, internal_name='cid')
 
     age = SchemaNode(Integer(), missing=None)
     psc = SchemaNode(Integer(), missing=None)
-    signalStrength = SchemaNode(Integer(), missing=None)
-    timingAdvance = SchemaNode(Integer(), missing=None)
+    signalStrength = InternalSchemaNode(
+        Integer(), missing=None, internal_name='signal')
+    timingAdvance = InternalSchemaNode(
+        Integer(), missing=None, internal_name='ta')
 
 
-class CellTowersSchema(SequenceSchema):
+class CellTowersSchema(InternalMixin, SequenceSchema):
 
     cell = CellTowerSchema()
 
 
-class WifiAccessPointSchema(MappingSchema):
+class WifiAccessPointSchema(InternalMixin, MappingSchema):
+    schema_type = InternalMapping
 
-    macAddress = SchemaNode(String(), missing=None)
-
+    macAddress = InternalSchemaNode(
+        String(), missing=None, internal_name='key')
     age = SchemaNode(Integer(), missing=None)
     channel = SchemaNode(Integer(), missing=None)
     frequency = SchemaNode(Integer(), missing=None)
-    signalStrength = SchemaNode(Integer(), missing=None)
-    signalToNoiseRatio = SchemaNode(Integer(), missing=None)
+    signalStrength = InternalSchemaNode(
+        Integer(), missing=None, internal_name='signal')
+    signalToNoiseRatio = InternalSchemaNode(
+        Integer(), missing=None, internal_name='snr')
 
 
-class WifiAccessPointsSchema(SequenceSchema):
+class WifiAccessPointsSchema(InternalMixin, SequenceSchema):
 
     wifi = WifiAccessPointSchema()
 
 
-class LocateV2Schema(MappingSchema):
+class LocateV2Schema(BaseLocateSchema):
 
-    carrier = SchemaNode(String(), missing=None)
-    homeMobileCountryCode = SchemaNode(Integer(), missing=None)
-    homeMobileNetworkCode = SchemaNode(Integer(), missing=None)
-    radioType = SchemaNode(String(),
-                           validator=OneOf(RADIO_STRINGS), missing=None)
+    carrier = InternalSchemaNode(String(), missing=None)
+    homeMobileCountryCode = InternalSchemaNode(Integer(), missing=None)
+    homeMobileNetworkCode = InternalSchemaNode(Integer(), missing=None)
+    radioType = InternalSchemaNode(
+        String(), validator=OneOf(RADIO_STRINGS),
+        missing=None, internal_name='radio')
 
-    cellTowers = CellTowersSchema(missing=())
-    wifiAccessPoints = WifiAccessPointsSchema(missing=())
+    cellTowers = CellTowersSchema(missing=(), internal_name='cell')
+    wifiAccessPoints = WifiAccessPointsSchema(missing=(), internal_name='wifi')
     fallbacks = FallbackSchema(missing=None)

--- a/ichnaea/api/locate/locate_v2/views.py
+++ b/ichnaea/api/locate/locate_v2/views.py
@@ -1,3 +1,4 @@
+from ichnaea.api.locate.locate_v2.schema import LocateV2Schema
 from ichnaea.api.locate.views import BaseLocateView
 
 
@@ -5,16 +6,13 @@ class LocateV2View(BaseLocateView):
 
     route = '/v1/geolocate'
     view_name = 'geolocate'
+    schema = LocateV2Schema
 
-    def view(self, api_key):
-        result = self.locate(api_key)
-        if not result:
-            return self.not_found()
-
+    def prepare_location_data(self, location_data):
         return {
             'location': {
-                'lat': result['lat'],
-                'lng': result['lon'],
+                'lat': location_data['lat'],
+                'lng': location_data['lon'],
             },
-            'accuracy': float(result['accuracy']),
+            'accuracy': float(location_data['accuracy']),
         }

--- a/ichnaea/api/locate/schema.py
+++ b/ichnaea/api/locate/schema.py
@@ -1,5 +1,6 @@
 import colander
 
+from ichnaea.api.schema import InternalMapping
 from ichnaea.models.base import ValidationMixin
 from ichnaea.models.cell import (
     CellAreaKey,
@@ -56,3 +57,20 @@ class ValidWifiLookupSchema(ValidWifiKeySchema, ValidWifiSignalSchema):
 class WifiLookup(WifiKeyMixin, WifiSignalMixin, ValidationMixin):
 
     _valid_schema = ValidWifiLookupSchema
+
+
+class BaseLocateSchema(colander.MappingSchema):
+    schema_type = InternalMapping
+
+    def deserialize(self, data):
+        data = super(BaseLocateSchema, self).deserialize(data)
+
+        if 'radio' in data:
+            radio = data.get('radio', None)
+            for cell in data.get('cell', ()):
+                if 'radio' not in cell:
+                    cell['radio'] = radio
+
+            del data['radio']
+
+        return data

--- a/ichnaea/api/schema.py
+++ b/ichnaea/api/schema.py
@@ -1,10 +1,10 @@
-import calendar
 import math
+import calendar
 import time
 
 import colander
 import iso8601
-from colander import MappingSchema, SchemaNode
+from colander import Mapping, MappingSchema, SchemaNode
 from colander import Boolean
 
 
@@ -95,3 +95,29 @@ class FallbackSchema(MappingSchema):
 
     lacf = SchemaNode(Boolean(), missing=True)
     ipf = SchemaNode(Boolean(), missing=True)
+
+
+class InternalMixin(object):
+
+    def __init__(self, *args, **kwargs):
+        self.internal_name = kwargs.pop('internal_name', None)
+        super(InternalMixin, self).__init__(*args, **kwargs)
+
+
+class InternalSchemaNode(InternalMixin, SchemaNode):
+    pass
+
+
+class InternalMapping(Mapping):
+
+    def _impl(self, node, *args, **kwargs):
+        result = super(InternalMapping, self)._impl(node, *args, **kwargs)
+        internal_result = {}
+        for subnode in node.children:
+            subnode_internal_name = getattr(
+                subnode, 'internal_name', subnode.name) or subnode.name
+
+            if result[subnode.name]:
+                internal_result[subnode_internal_name] = result[subnode.name]
+
+        return internal_result

--- a/ichnaea/api/submit/views.py
+++ b/ichnaea/api/submit/views.py
@@ -7,7 +7,6 @@ from redis import ConnectionError
 from ichnaea.data.tasks import queue_reports
 from ichnaea.api.error import (
     JSONParseError,
-    preprocess_request,
 )
 from ichnaea.api.views import BaseAPIView
 
@@ -50,11 +49,7 @@ class BaseSubmitView(BaseAPIView):
 
     def preprocess(self, api_key):
         try:
-            request_data, errors = preprocess_request(
-                self.request,
-                schema=self.schema(),
-                response=self.error_response,
-            )
+            request_data, errors = self.preprocess_request()
         except self.error_response:
             # capture JSON exceptions for submit calls
             self.raven_client.captureException()

--- a/ichnaea/api/tests.py
+++ b/ichnaea/api/tests.py
@@ -1,0 +1,26 @@
+from colander import MappingSchema, String
+
+from ichnaea.api.schema import InternalSchemaNode, InternalMapping
+from ichnaea.tests.base import TestCase
+
+
+class InternalSchemaNodeTests(TestCase):
+
+    def test_internal_schema_node_uses_internal_name(self):
+
+        class SampleSchema(MappingSchema):
+            schema_type = InternalMapping
+
+            input_name = InternalSchemaNode(
+                String(), internal_name='output_name')
+
+            def __init__(self, *args, **kwargs):
+                super(SampleSchema, self).__init__(*args, **kwargs)
+
+        input_data = {
+            'input_name': 'value',
+        }
+
+        output_data = SampleSchema().deserialize(input_data)
+        self.assertEqual(output_data['output_name'], 'value')
+        self.assertFalse('input_name' in output_data)


### PR DESCRIPTION
This is still split into separate commits in case we need to isolate and revert any specific change, should make it easier to understand each step.  This adds the Internal Mapping types, converts all of the request schemas to use them, and removes the Transform objects.

@hannosch r?