### PR TITLE
Disable scheduled pyup updates

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,4 +1,3 @@
-schedule: "every day"
 search: False
 update: insecure
 requirements:


### PR DESCRIPTION
Instead of opening a pyup PR every day, open one for each dependency. This should reduce the traffic from a new PR every day, plus the noise from auto-closed PRs.