### PR TITLE
Update docker tagging for "make build" target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,12 +97,12 @@ jobs:
               # push on master or git tag
               if [ "${CIRCLE_BRANCH}" == "master" ] || [ -n "${CIRCLE_TAG}" ]; then
                 echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
-                docker tag "mozilla/location" "mozilla/location:${DOCKER_TAG}"
+                docker tag "local/ichnaea_app" "mozilla/location:${DOCKER_TAG}"
                 retry docker push "mozilla/location:${DOCKER_TAG}"
 
                 # push `latest` on master only
                 if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                  docker tag "mozilla/location" "mozilla/location:latest"
+                  docker tag "local/ichnaea_app" "mozilla/location:latest"
                   retry docker push "mozilla/location:latest"
                 fi
               fi


### PR DESCRIPTION
``make build`` now tags the built image as ~``ichnaea_node:latest``~ ``local/ichnaea_app`` rather than ``mozilla/location``. Fix the circleci build step that that re-tags and pushes to dockerhub.

Follow-on work for issue #828.

**Update**: Force push to fix local tag name, commit comment.