### PR TITLE
Add docs for Mapbox API token

### DIFF
--- a/docker/config/my.env.dist
+++ b/docker/config/my.env.dist
@@ -6,3 +6,6 @@
 # containers, you can do that with these two variables.
 # ICHNAEA_UID=
 # ICHNAEA_GID=
+#
+# Set this to the Mapbox API token.
+# MAP_TOKEN=

--- a/docs/install/config.rst
+++ b/docs/install/config.rst
@@ -120,16 +120,18 @@ and made available via a HTTPS frontend (Amazon CloudFront).
     ASSET_URL = https://some_distribution_id.cloudfront.net
 
 
-Web
-~~~
+Mapbox
+~~~~~~
 
-The application contains both the HTTP API and some website content.
+The web site content uses Mapbox to generate tiles. In order to do this,
+it requires a Mapbox API token.
 
-The web functionality by default is limited to the public HTTP API.
-If the map related settings are configured, the website content is
-also being made available.
+You can create an account on their site: https://mapbox.com/
 
-The ``MAP_TOKEN`` specifies a Mapbox access token.
+After you have an account, you can create an API token at:
+https://accounts.mapbox.com/
+
+Set the ``MAP_TOKEN`` configuration value to your API token.
 
 .. code-block:: ini
 


### PR DESCRIPTION
This fleshes out the documentation on the Mapbox API token so it's
clearer.

Fixes #848