### PR TITLE
Add mock for shapely module

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,10 +3,16 @@
 import os
 import sphinx_rtd_theme
 import sys
+from unittest import mock
 
 
+# Add repository root so we can import ichnaea things
 REPO_DIR = os.path.dirname(os.path.dirname(__file__))
 sys.path.append(REPO_DIR)
+
+
+# Fake the shapely module so things will import
+sys.modules['shapely'] = mock.MagicMock()
 
 
 project = 'Ichnaea'


### PR DESCRIPTION
Adding a mock for the shapely module allows ReadTheDocs to build the
docs even though Shapely isn't installed.

Fixes #859.