### PR TITLE
Remove the built docs submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.so
 *.sublime-*
 .DS_Store
-docs/build/doctrees/
+docs/build
 ichnaea/content/static/tiles/
 my.env
 .docker-build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "docs/build/html"]
-	path = docs/build/html
-	url = https://github.com/mozilla/ichnaea.git
-	branch = gh-pages


### PR DESCRIPTION
Remove the built HTML documents submodule. Documents can still be built locally with `make docs`, but they will be ignored by git.

Part of #859.