### PR TITLE
Update SQLAlchemy code for 1.2, 1.3

### DIFF
--- a/ichnaea/data/area.py
+++ b/ichnaea/data/area.py
@@ -156,9 +156,7 @@ class CellAreaUpdater(object):
 
         if area is None:
             session.execute(
-                self.area_table.insert(
-                    mysql_on_duplicate="num_cells = num_cells"  # no-op
-                ).values(
+                self.area_table.insert().values(
                     areaid=areaid,
                     radio=radio,
                     mcc=mcc,
@@ -174,6 +172,8 @@ class CellAreaUpdater(object):
                     num_cells=num_cells,
                     last_seen=last_seen,
                 )
+                # If there was an unexpected insert, log warning instead of error
+                .prefix_with("IGNORE", dialect="mysql")
             )
         else:
             session.execute(

--- a/ichnaea/data/datamap.py
+++ b/ichnaea/data/datamap.py
@@ -64,10 +64,11 @@ class DataMapUpdater(object):
 
         if new_values:
             # do a batch insert of new grids
-            stmt = self.shard.__table__.insert(
-                mysql_on_duplicate="modified = modified"  # no-op
+            session.execute(
+                self.shard.__table__.insert().values(new_values)
+                # If there was an unexpected insert, log warning instead of error
+                .prefix_with("IGNORE", dialect="mysql")
             )
-            session.execute(stmt.values(new_values))
 
         if update_values:
             # do a batch update of grids

--- a/ichnaea/data/station.py
+++ b/ichnaea/data/station.py
@@ -509,16 +509,16 @@ class StationUpdater(object):
 
         if new_data["new"]:
             session.execute(
-                shard.__table__.insert(mysql_on_duplicate="samples = samples").values(
-                    new_data["new"]
-                )
+                shard.__table__.insert().values(new_data["new"])
+                # If there was an unexpected insert, log warning instead of error
+                .prefix_with("IGNORE", dialect="mysql")
             )
 
         if new_data["new_block"]:
             session.execute(
-                shard.__table__.insert(
-                    mysql_on_duplicate="block_count = block_count"
-                ).values(new_data["new_block"])
+                shard.__table__.insert().values(new_data["new_block"])
+                # If there was an unexpected insert, log warning instead of error
+                .prefix_with("IGNORE", dialect="mysql")
             )
 
         updates = new_data["block"] + new_data["change"] + new_data["replace"]

--- a/ichnaea/db.py
+++ b/ichnaea/db.py
@@ -8,13 +8,11 @@ from alembic import command
 from alembic.config import Config as AlembicConfig
 import certifi
 from pymysql.err import DatabaseError
-from sqlalchemy import create_engine, exc
+from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm.session import Session
 from sqlalchemy.pool import NullPool, QueuePool
-from sqlalchemy.sql import func, select
 from sqlalchemy.sql.expression import Insert
 
 from ichnaea.conf import settings
@@ -175,7 +173,7 @@ class Database(object):
         self.engine = create_engine(uri, **options)
 
         self.session_factory = sessionmaker(
-            bind=self.engine, class_=PingableSession, autocommit=False, autoflush=False
+            bind=self.engine, autocommit=False, autoflush=False
         )
 
     def close(self):
@@ -187,22 +185,6 @@ class Database(object):
 
     def __repr__(self):
         return self.uri
-
-
-class PingableSession(Session):
-    """A custom pingable database session."""
-
-    def __init__(self, *args, **kw):
-        # disable automatic docstring
-        return super(PingableSession, self).__init__(*args, **kw)
-
-    def ping(self):
-        """Use this active session to check the database connectivity."""
-        try:
-            self.execute(select([func.now()])).first()
-        except exc.OperationalError:
-            return False
-        return True
 
 
 def create_db(uri=None):

--- a/ichnaea/db.py
+++ b/ichnaea/db.py
@@ -8,12 +8,12 @@ from alembic import command
 from alembic.config import Config as AlembicConfig
 import certifi
 from pymysql.err import DatabaseError
-from sqlalchemy import create_engine, exc, event
+from sqlalchemy import create_engine, exc
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import Session
-from sqlalchemy.pool import NullPool, Pool, QueuePool
+from sqlalchemy.pool import NullPool, QueuePool
 from sqlalchemy.sql import func, select
 from sqlalchemy.sql.expression import Insert
 
@@ -142,6 +142,7 @@ class Database(object):
             options.update(
                 {
                     "poolclass": QueuePool,
+                    "pool_pre_ping": True,
                     "pool_recycle": 3600,
                     "pool_size": 10,
                     "pool_timeout": 10,
@@ -180,15 +181,6 @@ class Database(object):
     def close(self):
         self.engine.pool.dispose()
 
-    def ping(self):
-        """
-        Check database connectivity.
-        On success returns `True`, otherwise `False`.
-        """
-        with db_worker_session(self, commit=False) as session:
-            success = session.ping()
-        return success
-
     def session(self):
         """Return a session for this database."""
         return self.session_factory()
@@ -211,36 +203,6 @@ class PingableSession(Session):
         except exc.OperationalError:
             return False
         return True
-
-
-@event.listens_for(Pool, "checkout")
-def check_connection(dbapi_conn, conn_record, conn_proxy):
-    """
-    Listener for pool checkout events that pings every connection before
-    using it. Implements the `pessimistic disconnect handling strategy
-    <https://docs.sqlalchemy.org/en/latest/core/pooling.html#disconnect-handling-pessimistic>`_.
-    """
-    try:
-        # dbapi_con.ping() ends up calling mysql_ping()
-        # http://dev.mysql.com/doc/refman/5.6/en/mysql-ping.html
-        dbapi_conn.ping(reconnect=True)
-    except exc.OperationalError as ex:
-        error_codes = [
-            # Connection refused
-            2003,
-            # MySQL server has gone away
-            2006,
-            # Lost connection to MySQL server during query
-            2013,
-            # Lost connection to MySQL server at '%s', system error: %d
-            2055,
-        ]
-
-        if ex.args[0] in error_codes:
-            # caught by pool, which will retry with a new connection
-            raise exc.DisconnectionError()
-        else:
-            raise
 
 
 def create_db(uri=None):

--- a/ichnaea/db.py
+++ b/ichnaea/db.py
@@ -10,10 +10,8 @@ import certifi
 from pymysql.err import DatabaseError
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
-from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool, QueuePool
-from sqlalchemy.sql.expression import Insert
 
 from ichnaea.conf import settings
 
@@ -40,19 +38,6 @@ def get_alembic_config():
     cfg.set_section_option("alembic", "script_location", script_location)
     cfg.set_section_option("alembic", "sqlalchemy.url", settings("db_ddl_uri"))
     return cfg
-
-
-@compiles(Insert, "mysql")
-def on_duplicate(insert, compiler, **kw):
-    """Custom MySQL insert on_duplicate support."""
-    stmt = compiler.visit_insert(insert, **kw)
-    my_var = insert.dialect_kwargs.get("mysql_on_duplicate", None)
-    if my_var:
-        stmt += " ON DUPLICATE KEY UPDATE %s" % my_var
-    return stmt
-
-
-Insert.argument_for("mysql", "on_duplicate", None)
 
 
 def configure_db(type_=None, uri=None, transport="default", _db=None):

--- a/ichnaea/log.py
+++ b/ichnaea/log.py
@@ -34,7 +34,7 @@ LOGGING_CONFIG = dict(
     loggers=dict(
         alembic={"level": logging.INFO, "qualname": "alembic"},
         ichnaea={"level": logging.INFO, "qualname": "ichnaea"},
-        sqlalchemny={"level": logging.WARN, "qualname": "sqlalchemy.engine"},
+        sqlalchemy={"level": logging.WARN, "qualname": "sqlalchemy.engine"},
     ),
 )
 

--- a/ichnaea/tests/test_db.py
+++ b/ichnaea/tests/test_db.py
@@ -1,8 +1,3 @@
-import warnings
-
-from pymysql import err
-from sqlalchemy import text
-
 from ichnaea.models.wifi import WifiShard0
 
 
@@ -18,19 +13,6 @@ class TestDatabase(object):
     def test_table_creation(self, session):
         result = session.execute("select * from cell_gsm;")
         assert result.first() is None
-
-    def test_show_warnings_backport(self, session):
-        # Fixed in PyMySQL 0.6.7
-        stmt = text("DROP TABLE IF EXISTS a; DROP TABLE IF EXISTS b;")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", err.Warning)
-            session.execute(stmt)
-
-    def test_executemany_backport(self, session):
-        # Fixed in PyMySQL 0.6.7
-        session.add(WifiShard0(mac="000000123456"))
-        session.add(WifiShard0(mac="000000abcdef"))
-        session.commit()
 
     def test_excecutemany_on_duplicate(self, session):
         stmt = WifiShard0.__table__.insert(

--- a/ichnaea/tests/test_db.py
+++ b/ichnaea/tests/test_db.py
@@ -15,9 +15,6 @@ class TestDatabase(object):
         assert sync_db.engine.name == "mysql"
         assert sync_db.engine.dialect.driver == "mysqlconnector"
 
-    def test_ping(self, db):
-        assert db.ping()
-
     def test_table_creation(self, session):
         result = session.execute("select * from cell_gsm;")
         assert result.first() is None

--- a/ichnaea/tests/test_db.py
+++ b/ichnaea/tests/test_db.py
@@ -1,6 +1,3 @@
-from ichnaea.models.wifi import WifiShard0
-
-
 class TestDatabase(object):
     def test_constructor(self, db):
         assert db.engine.name == "mysql"
@@ -13,17 +10,3 @@ class TestDatabase(object):
     def test_table_creation(self, session):
         result = session.execute("select * from cell_gsm;")
         assert result.first() is None
-
-    def test_excecutemany_on_duplicate(self, session):
-        stmt = WifiShard0.__table__.insert(
-            mysql_on_duplicate='mac = "\x00\x00\x000\x00\x00", region="\xe4"'
-        )
-        values = [
-            {"mac": "000000100000", "region": "DE"},
-            {"mac": "000000200000", "region": "\xe4"},
-            {"mac": "000000200000", "region": "\xf6"},
-        ]
-        session.execute(stmt.values(values))
-        rows = session.query(WifiShard0).all()
-        assert set([row.mac for row in rows]) == set(["000000100000", "000000300000"])
-        assert set([row.region for row in rows]) == set(["DE", "\xe4"])


### PR DESCRIPTION
Adjust the code to reflect features added in SQLAlchemy 1.2 and 1.3, and remove the related custom code and tests.

A new option ``create_engine(pool_pre_ping=True)`` tests if a connection has been disconnected by the server before using it, replacing custom event handler ``check_connection``.

A similar "ping" function is used to determine that the database is available in the ``__heartbeat__`` view. This code is moved from the custom session to the view, so that the standard SQLAlchemy session class can be used.

A MySQL-specific ``INSERT`` clause, ``ON DUPLICATE KEY UPDATE``, was used to avoid errors when an ``INSERT`` refers to an existing key. This feels like overkill, since the code usually checks for existence with a ``SELECT``, but it could have been added based on real-world errors. The clause was added with a custom ``INSERT`` compile rule.

When the strategy was to throw away the ``INSERT``, use ``INSERT IGNORE`` (via ``.prefix_with("IGNORE")`` to ignore the error. When the strategy was to update the existing row instead, use ``ON DUPLICATE KEY UPDATE`` with the new ``.on_duplicate_key_update()``. Both of these syntax additions are specific to MySQL.

Fixes #887, which goes into more detail about the new features.