### PR TITLE
Fix database ping in webapp startup

### DIFF
--- a/ichnaea/db.py
+++ b/ichnaea/db.py
@@ -10,8 +10,10 @@ import certifi
 from pymysql.err import DatabaseError
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool, QueuePool
+from sqlalchemy.sql import func, select
 
 from ichnaea.conf import settings
 
@@ -170,6 +172,16 @@ class Database(object):
 
     def __repr__(self):
         return self.uri
+
+
+def ping_session(db_session):
+    """Check that a database session is available, using a simple query."""
+    try:
+        db_session.execute(select([func.now()])).first()
+    except OperationalError:
+        return False
+    else:
+        return True
 
 
 def create_db(uri=None):

--- a/ichnaea/webapp/config.py
+++ b/ichnaea/webapp/config.py
@@ -12,7 +12,7 @@ from ichnaea.api.locate.searcher import (
 )
 from ichnaea.cache import configure_redis
 from ichnaea.content.views import configure_content
-from ichnaea.db import configure_db, db_session
+from ichnaea.db import configure_db, db_session, db_worker_session, ping_session
 from ichnaea.geoip import configure_geoip
 from ichnaea.http import configure_http_session
 from ichnaea.log import configure_logging, configure_raven, configure_stats
@@ -114,7 +114,8 @@ def main(
 
     # Should we try to initialize and establish the outbound connections?
     if ping_connections:
-        registry.db.ping()
+        with db_worker_session(registry.db, commit=False) as session:
+            ping_session(session)
         registry.redis_client.ping()
 
     return config.make_wsgi_app()

--- a/ichnaea/webapp/monitor.py
+++ b/ichnaea/webapp/monitor.py
@@ -5,11 +5,9 @@ import time
 
 from pyramid.httpexceptions import HTTPServiceUnavailable
 
+from ichnaea.db import ping_session
 from ichnaea.util import contribute_info, version_info
 from ichnaea.webapp.view import BaseView
-
-from sqlalchemy.exc import OperationalError
-from sqlalchemy.sql import func, select
 
 
 def _check_timed(ping_function):
@@ -22,16 +20,7 @@ def _check_timed(ping_function):
 
 def check_database(request):
     """Check that the database is available for a simple query."""
-
-    def ping_database():
-        try:
-            request.db_session.execute(select([func.now()])).first()
-        except OperationalError:
-            return False
-        else:
-            return True
-
-    return _check_timed(ping_database)
+    return _check_timed(lambda: ping_session(request.db_session))
 
 
 def check_geoip(request):


### PR DESCRIPTION
Previously, a ``Database.ping()`` method was used to test the database connection when configuring the webapp. This was removed in the previous PR #892 (fixing #887) because it appeared to be unused, based on a code search and tests passing.

Instead of bringing ``.ping()`` back for a single caller, add a function ``ichnaea.db.ping_session()``, which can be used to test the connectivity of a database session. This is now used when configuring the webapp and when calling the ``__heartbeat__`` endpoint.