### PR TITLE
Implement basic apikey manipulation cli

### DIFF
--- a/ichnaea/alembic/versions/000000000000_base.py
+++ b/ichnaea/alembic/versions/000000000000_base.py
@@ -13,7 +13,6 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import text
 
-from ichnaea.conf import settings
 
 DBCreds = namedtuple("DBCreds", "user pwd")
 
@@ -29,59 +28,12 @@ with open(BASE_SQL_PATH, "r") as fd:
     BASE_SQL = fd.read().strip()
 
 
-def _db_creds(conn_uri):
-    # for example 'mysql+pymysql://user:pwd@localhost/location'
-    result = conn_uri.split("@")[0].split("//")[-1].split(":")
-    return DBCreds(*result)
-
-
-def _add_users(conn):
-    # We don't take into account hostname or database restrictions
-    # the users / grants, but use global privileges.
-    creds = {}
-    creds["rw"] = _db_creds(settings("db_readwrite_uri"))
-    creds["ro"] = _db_creds(settings("db_readonly_uri"))
-
-    stmt = text("SELECT user FROM mysql.user")
-    result = conn.execute(stmt)
-    userids = set([r[0] for r in result.fetchall()])
-
-    create_stmt = text("CREATE USER :user IDENTIFIED BY :pwd")
-    grant_stmt = text("GRANT delete, insert, select, update ON *.* TO :user")
-    added = False
-    for cred in creds.values():
-        if cred.user not in userids:
-            conn.execute(create_stmt.bindparams(user=cred.user, pwd=cred.pwd))
-            conn.execute(grant_stmt.bindparams(user=cred.user))
-            userids.add(cred.user)
-            added = True
-    if added:
-        conn.execute("FLUSH PRIVILEGES")
-
-
 def upgrade():
     conn = op.get_bind()
 
     log.info("Create initial base schema")
     op.execute(sa.text(BASE_SQL))
     log.info("Initial schema created.")
-
-    # Add rw/ro users
-    _add_users(conn)
-
-    # Add test API key
-    stmt = text("select valid_key from api_key")
-    result = conn.execute(stmt).fetchall()
-    if not ("test",) in result:
-        stmt = text(
-            """\
-INSERT INTO api_key
-(valid_key, allow_fallback, allow_locate)
-VALUES
-('test', 0, 1)
-"""
-        )
-        conn.execute(stmt)
 
     # Setup internal export
     stmt = text("select name from export_config")

--- a/ichnaea/api/key.py
+++ b/ichnaea/api/key.py
@@ -12,7 +12,7 @@ _MARKER = object()
 API_CACHE_TIMEOUT = 300 + randint(-30, 30)
 API_CACHE = lru.ExpiringLRUCache(500, default_timeout=API_CACHE_TIMEOUT)
 
-_API_KEY_COLUMN_NAMES = (
+API_KEY_COLUMN_NAMES = (
     "valid_key",
     "maxreq",
     "allow_fallback",
@@ -33,7 +33,7 @@ def get_key(session, valid_key):
     value = API_CACHE.get(valid_key, _MARKER)
     if value is _MARKER:
         columns = ApiKey.__table__.c
-        fields = [getattr(columns, f) for f in _API_KEY_COLUMN_NAMES]
+        fields = [getattr(columns, f) for f in API_KEY_COLUMN_NAMES]
         row = (
             session.execute(select(fields).where(columns.valid_key == valid_key))
         ).fetchone()

--- a/ichnaea/conf.py
+++ b/ichnaea/conf.py
@@ -19,8 +19,8 @@ class AppConfig(RequiredConfigMixin):
         default="false",
         parser=bool,
         doc=(
-            "Whether (True) or not (False) we are in a local dev environment."
-            " There are some things that get configured one way in a developer's "
+            "Whether (True) or not (False) we are in a local dev environment. "
+            "There are some things that get configured one way in a developer's "
             "environment and another way in a server environment."
         ),
     )
@@ -34,10 +34,12 @@ class AppConfig(RequiredConfigMixin):
     required_config.add_option(
         "asset_bucket",
         default="",
-        doc="name of AWS S3 bucket to store map tile image assets in",
+        doc="name of AWS S3 bucket to store map tile image assets and export downloads",
     )
     required_config.add_option(
-        "asset_url", default="", doc="Amazon CloudFront url for map tile image assets"
+        "asset_url",
+        default="",
+        doc="url for map tile image assets and export downloads",
     )
 
     # Database related settings

--- a/ichnaea/scripts/apikey.py
+++ b/ichnaea/scripts/apikey.py
@@ -30,6 +30,8 @@ def create_api_key(key):
                     allow_fallback=False,
                     allow_locate=True,
                     allow_region=True,
+                    store_sample_locate=100,
+                    store_sample_submit=100,
                 )
             )
             print("Created API key: %r" % key)

--- a/ichnaea/scripts/apikey.py
+++ b/ichnaea/scripts/apikey.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+"""
+Create and manipulate API keys.
+"""
+
+import argparse
+import uuid
+import sys
+
+from sqlalchemy import select
+from sqlalchemy.dialects.mysql import insert
+from sqlalchemy.exc import IntegrityError
+
+from ichnaea.api.key import API_KEY_COLUMN_NAMES, Key
+from ichnaea.models.api import ApiKey
+from ichnaea.db import configure_db, db_worker_session
+from ichnaea.util import print_table
+
+
+def create_api_key(key):
+    """Create a new api key."""
+    key = key or str(uuid.uuid4())
+
+    db = configure_db("rw")
+    with db_worker_session(db) as session:
+        try:
+            session.execute(
+                insert(ApiKey.__table__).values(
+                    valid_key=key,
+                    allow_fallback=False,
+                    allow_locate=True,
+                    allow_region=True,
+                )
+            )
+            print("Created API key: %r" % key)
+        except IntegrityError:
+            print("API key %r exists" % key)
+
+
+def list_api_keys():
+    """List all api keys in db."""
+    show_fields = ["valid_key", "allow_fallback", "allow_locate", "allow_region"]
+
+    db = configure_db("rw")
+    with db_worker_session(db) as session:
+        columns = ApiKey.__table__.columns
+        fields = [getattr(columns, f) for f in show_fields]
+        rows = session.execute(select(fields)).fetchall()
+
+    print("%d api keys." % len(rows))
+    if rows:
+        # Add header row
+        table = [show_fields]
+        # Add rest of the rows; the columns are in the order of show_fields so we
+        # don't have to do any re-ordering
+        table.extend(rows)
+        print_table(table)
+
+
+def show_api_key_details(key):
+    """Print api key details to stdout."""
+    db = configure_db("rw")
+    with db_worker_session(db) as session:
+        columns = ApiKey.__table__.columns
+        fields = [getattr(columns, f) for f in API_KEY_COLUMN_NAMES]
+        row = (
+            session.execute(select(fields).where(columns.valid_key == key))
+        ).fetchone()
+        if row is not None:
+            key = Key(**dict(row.items()))
+        else:
+            key = None
+    table = []
+    for field in API_KEY_COLUMN_NAMES:
+        table.append([field, getattr(key, field, "")])
+
+    print_table(table, " : ")
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Manipulate API keys.")
+    subparsers = parser.add_subparsers(dest="cmd")
+    subparsers.required = True
+
+    subparsers.add_parser("list", help="list api keys")
+    create_parser = subparsers.add_parser("create", help="create new api key")
+    create_parser.add_argument(
+        "key", nargs="?", help="the api key; defaults to a uuid4"
+    )
+
+    show_parser = subparsers.add_parser("show", help="show details for an api key")
+    show_parser.add_argument("key", help="the key to show details for")
+
+    args = parser.parse_args(argv[1:])
+
+    if args.cmd == "create":
+        return create_api_key(args.key)
+    if args.cmd == "show":
+        return show_api_key_details(args.key)
+    if args.cmd == "list":
+        return list_api_keys()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/ichnaea/scripts/db.py
+++ b/ichnaea/scripts/db.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+"""
+Create and drop the db.
+
+Use this only in a local dev environment.
+"""
+
 import argparse
 import sys
 

--- a/ichnaea/util.py
+++ b/ichnaea/util.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from datetime import datetime
 import gzip
 from io import BytesIO
+from itertools import zip_longest
 import json
 import os
 import shutil
@@ -95,3 +96,29 @@ def contribute_info():
             except json.JsonDecodeException:
                 pass
     return {}
+
+
+def print_table(table, delimiter=" | "):
+    """Takes a list of lists and prints a table to stdout.
+
+    :arg list-of-lists table: the table to print out
+    :arg str delimiter: the delimiter between fields in a row
+
+    """
+    # Find the max size value for each column
+    col_maxes = [0] * len(table[0])
+    for row in table:
+        col_maxes = [
+            max(len(str(field)), col_max)
+            for field, col_max in zip_longest(row, col_maxes, fillvalue=0)
+        ]
+
+    for row in table:
+        print(
+            delimiter.join(
+                [
+                    str(field).ljust(col_max)
+                    for field, col_max in zip_longest(row, col_maxes, fillvalue="")
+                ]
+            )
+        )


### PR DESCRIPTION
This implements a basic apikey manipulation cli that lets you list keys, show key details, and create keys.

In doing that, I removed the code in the base migration that creates database users and a test key. Seems like it's safer if both of them are created explicitly with intention rather than accidentally by running db migrations.

This is part of issue #503. I figured I'd break it up into parts as I finished them rather than one big sample data code dump.

To test:

1. `make build`
2. `make setup`
3. `make test` to verify tests still work
4. `docker-compose run app shell ./ichnaea/scripts/apikey.py` and play with that

That `docker-compose` line is a bit much. With Socorro, we wrote a `socorro-cmd` as a frontend for all the scripts. I removed the `dev` script from this repo that sort of served a similar purpose a month ago. Maybe we should re-add something like that if we use it often.