### PR TITLE
Remove monkey_session fixture

### DIFF
--- a/ichnaea/conftest.py
+++ b/ichnaea/conftest.py
@@ -6,7 +6,6 @@ import warnings
 from alembic import command
 from maxminddb.const import MODE_AUTO
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from sqlalchemy import event, inspect, text
 from sqlalchemy.exc import ProgrammingError
 import webtest
@@ -71,13 +70,6 @@ GEOIP_DATA = {
         "score": 0.9,
     },
 }
-
-
-@pytest.fixture(scope="session")
-def monkeysession(request):
-    mp = MonkeyPatch()
-    request.addfinalizer(mp.undo)
-    return mp
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
The one user of ``monkey_session`` (``map_config``) was removed in PR #894, so
removing ``monkey_session`` as well. It appears the same functionality can
be accomplished by using the [monkeypatch fixture](https://docs.pytest.org/en/latest/reference.html#monkeypatch) in a derived fixture, so we don't need to keep this implementation around just in case.