### PR TITLE
Add CELERY_WORKER_CONCURRENCY setting and fix Celery logging

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -13,3 +13,6 @@ DB_READWRITE_URI=mysql+pymysql://root:location@mysql:3306/location
 
 # DB url for running alembic migrations
 SQLALCHEMY_URL=mysql+pymysql://root:location@mysql:3306/location
+
+# Limit Celery workers to 1 in the local dev environment
+CELERY_WORKER_CONCURRENCY=1

--- a/docker/run_scheduler.sh
+++ b/docker/run_scheduler.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
+
 celery -A ichnaea.taskapp.app:celery_app beat \
     -s "/var/run/location/celerybeat-schedule" \
-    --pidfile="/var/run/location/celerybeat.pid" \
-    --loglevel=INFO
+    --pidfile="/var/run/location/celerybeat.pid"

--- a/docker/run_worker.sh
+++ b/docker/run_worker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-celery -A ichnaea.taskapp.app:celery_app worker \
-    --loglevel=INFO
+
+celery -A ichnaea.taskapp.app:celery_app worker

--- a/ichnaea/conf.py
+++ b/ichnaea/conf.py
@@ -73,6 +73,12 @@ class AppConfig(RequiredConfigMixin):
     )
 
     required_config.add_option(
+        "celery_worker_concurrency",
+        parser=int,
+        doc="the number of concurrent Celery worker processes executing tasks",
+    )
+
+    required_config.add_option(
         "mapbox_token",
         default="",
         doc=(

--- a/ichnaea/log.py
+++ b/ichnaea/log.py
@@ -22,9 +22,11 @@ def configure_logging():
 
     if local_dev_env:
         level = "DEBUG"
+        celery_level = "INFO"
         handlers = ["console"]
     else:
         level = "INFO"
+        celery_level = "WARNING"
         handlers = ["mozlog"]
 
     logging_config = {
@@ -51,6 +53,7 @@ def configure_logging():
         },
         "loggers": {
             "alembic": {"propagate": False, "handlers": handlers, "level": level},
+            "celery": {"propagate": False, "handlers": handlers, "level": celery_level},
             "ichnaea": {"propagate": False, "handlers": handlers, "level": level},
         },
         "root": {"handlers": handlers, "level": "WARNING"},

--- a/ichnaea/taskapp/app.py
+++ b/ichnaea/taskapp/app.py
@@ -3,14 +3,29 @@ Holds global celery application state and startup / shutdown handlers.
 """
 from celery import Celery
 from celery.app import app_or_default
-from celery.signals import beat_init, worker_process_init, worker_process_shutdown
+from celery.signals import (
+    beat_init,
+    worker_process_init,
+    worker_process_shutdown,
+    setup_logging,
+)
 
+from ichnaea.log import configure_logging
 from ichnaea.taskapp.config import (
     configure_celery,
     init_beat,
     init_worker,
     shutdown_worker,
 )
+
+
+@setup_logging.connect
+def setup_logging_process(loglevel, logfile, format, colorize, **kwargs):
+    """Called at scheduler and worker setup.
+
+    Configures logging using the same configuration as the webapp.
+    """
+    configure_logging()
 
 
 @beat_init.connect

--- a/ichnaea/taskapp/config.py
+++ b/ichnaea/taskapp/config.py
@@ -1,5 +1,5 @@
 """
-Contains celery specific one time configuration code.
+Contains celery specific one-time configuration code.
 """
 
 from kombu import Queue

--- a/ichnaea/taskapp/settings.py
+++ b/ichnaea/taskapp/settings.py
@@ -2,15 +2,15 @@
 Contains :ref:`celery settings <celery:configuration>`.
 """
 
-from ichnaea.conf import settings
+from ichnaea.conf import settings as app_settings
 from ichnaea.taskapp.config import TASK_QUEUES
 
-if settings("testing"):
+if app_settings("testing"):
     task_always_eager = True
     task_eager_propagates = True
 
-broker_url = settings("redis_uri")
-result_backend = settings("redis_uri")
+broker_url = app_settings("redis_uri")
+result_backend = app_settings("redis_uri")
 
 # Based on `Celery / Redis caveats
 # <celery.rtfd.org/en/latest/getting-started/brokers/redis.html#caveats>`_.
@@ -40,3 +40,6 @@ task_ignore_result = True
 worker_prefetch_multiplier = 8
 worker_disable_rate_limits = True
 task_compression = "gzip"
+
+# Worker concurrency
+worker_concurrency = app_settings("celery_worker_concurrency")


### PR DESCRIPTION
This adds a `CELERY_WORKER_CONCURRENCY` setting.

This redoes Celery logging configuration so it uses the same configuration as the rest of Ichnaea including whether or not to use mozlog.

Fixes #909.
Fixes #913.

To test:

1. Run `make runcelery`.

   Should spin up one celery worker with concurrency: 1. You can tell by looking at the output when it spits out a `[config]` section to the right of a giant ASCII C.

   Logging output should look "normal" for the scheduler and worker. Like this:
   ```
   worker_1     | 2019-10-02 15:23:27,433 INFO  [celery.app.trace] - Task ichnaea.data.tasks.update_incoming[7a798f9e-7b81-4f56-b537-9979cfa60cd6] succeeded in 0.061439532990334556s: None
   ```
2. Add `CELERY_WORKER_CONCURRENCY=2` and `LOCAL_DEV_ENV=False` to `my.env` and then run `make runcelery`.

   Should spin up one celery worker with concurrency: 2.

   Output is in mozlog format after the scheduler and worker have started up. Like this:
   ```
   worker_1     | {"Timestamp": 1570029523458684160, "Type": "celery.worker.consumer.connection", "Logger": "ichnaea", "Hostname": "3fa9d5c12283", "EnvVersion": "2.0", "Severity": 6, "Pid": 7, "Fields": {"msg": "Connected to redis://redis:6379/0"}}
   ```