### PR TITLE
make mysql: connect to the location database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ shell: my.env .docker-build
 .PHONY: mysql
 mysql: my.env .docker-build
 	${DC} up -d mysql
-	${DC} exec mysql mysql --user root --password=location
+	${DC} exec mysql mysql --user root --password=location location
 
 .PHONY: test
 test: my.env .docker-build


### PR DESCRIPTION
When running ``make mysql``, connect to the ``location`` database, so that a ``connect location`` is not needed for querying the regular database.