### PR TITLE
update_statregion: Use ORM, not bulk_*_mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ default:
 	@echo "  lint             - lint code"
 	@echo "  lintfix          - reformat code"
 	@echo "  test             - run unit tests"
+	@echo "  testcoverage     - run unit tests with coverage report"
 	@echo "  testshell        - open a shell in the test environment"
 	@echo "  docs             - generate Sphinx HTML documentation, including API docs"
 	@echo "  buildjs          - generate js static assets"
@@ -86,6 +87,10 @@ mysql: my.env .docker-build
 .PHONY: test
 test: my.env .docker-build
 	./bin/test_env.sh
+
+.PHONY: testcoverage
+testcoverage: my.env .docker-build
+	./bin/test_env.sh --cov=ichnaea --cov-branch
 
 .PHONY: testshell
 testshell: my.env .docker-build

--- a/bin/test_env.sh
+++ b/bin/test_env.sh
@@ -94,6 +94,6 @@ docker run \
     --tty \
     --interactive \
     --entrypoint= \
-    "${TESTIMAGE}" /app/docker/run_tests.sh
+    "${TESTIMAGE}" /app/docker/run_tests.sh "$@"
 
 echo "Done!"

--- a/ichnaea/data/tests/test_stats.py
+++ b/ichnaea/data/tests/test_stats.py
@@ -1,7 +1,5 @@
 from datetime import timedelta
 
-import pytest
-
 from ichnaea.cache import redis_pipeline
 from ichnaea.data.tasks import cleanup_stat, update_statcounter, update_statregion
 from ichnaea.models import Radio, RegionStat, Stat, StatCounter, StatKey
@@ -196,7 +194,6 @@ class TestStatRegion(object):
         assert stat.blue == 0
         assert stat.wifi == 5
 
-    @pytest.mark.xfail(strict=True, reason="raises StaleDataError")
     def test_update_no_changes(self, celery, session):
         """update_statregion does nothing if counts are accurate."""
         CellAreaFactory(radio=Radio.gsm, region="CA", num_cells=2)


### PR DESCRIPTION
MySQL returns the number of rows affected by an ``UPDATE``, and ``bulk_update_mappings`` raises a ``StaleDataError`` if the affected rows are less than the rows sent.  This means that the update fails if the radio count is the same for any region. Instead, return to using the ORM methods, which sends several ``UPDATE``s, but only when the data changes.

Without this change, the new test ``test_update_no_change`` fails when ``update_statregion`` is called with no changes to the ``CellArea`` counts:

```
...
  File "/app/ichnaea/data/stats.py", line 156, in _update_stats
    session.bulk_update_mappings(RegionStat, updates)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 2849, in bulk_update_mappings
    mapper, mappings, True, False, False, False, False
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 2888, in _bulk_save_mappings
    transaction.rollback(_capture_exception=True)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py", line 68, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 153, in reraise
    raise value
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 2873, in _bulk_save_mappings
    update_changed_only,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/persistence.py", line 180, in _bulk_update
    bookkeeping=False,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/persistence.py", line 1029, in _emit_update_statements
    % (table.description, len(records), rows)
sqlalchemy.orm.exc.StaleDataError: UPDATE statement on table 'region_stat' expected to update 4 row(s); 0 were matched.
```

This also issues a ``ROLLBACK``, so it is not enough to catch the error.  Any rows with the same data would need to be removed from the update list, which would require querying and comparing to the current values, which is exactly what using the SQLAlchemy ORM does. This optimization to use bulk inserts and updates doesn't seem worth it for a table of 200-300 records that is populated in a task.