### PR TITLE
Add field definitions for /v1/submit/ API docs

### DIFF
--- a/docs/api/submit.rst
+++ b/docs/api/submit.rst
@@ -73,9 +73,6 @@ Here is an example position report:
 Field Definition
 ================
 
-The record fields have the same meaning and requirements as explained
-in the :ref:`api_search`.
-
 The only required fields are ``lat`` and ``lon`` and at least one Bluetooth,
 cell, or WiFi entry. If neither ``lat`` nor ``lon`` are included, the record
 will be discarded.
@@ -96,6 +93,115 @@ observing the environment.
 
 The ``time`` has to be in UTC time, encoded in ISO 8601. If not provided,
 the server time will be used.
+
+
+Bluetooth Fields
+----------------
+
+For ``blue`` entries, the ``key`` field is required.
+
+key **(required)**
+    The ``key`` is the mac address of the Bluetooth network. For example,
+    a valid key would look similar to ``ff:23:45:67:89:ab``.
+
+age
+    The number of milliseconds since this BLE beacon was last seen.
+
+signal
+    The received signal strength (RSSI) in dBm, typically in the range of
+    -10 to -127.
+
+name
+    The name of the Bluetooth network.
+
+
+Cell Fields
+-----------
+
+radio
+    The type of radio network. One of ``gsm``, ``umts`` or ``lte``.
+
+mcc
+    The mobile country code.
+
+mnc
+    The mobile network code.
+
+lac
+    The location area code for GSM and WCDMA networks. The tracking area
+    code for LTE networks.
+
+cid
+    The cell id or cell identity.
+
+age
+    The number of milliseconds since this networks was last detected.
+
+psc
+    The primary scrambling code for WCDMA and physical cell id for LTE.
+
+signal
+    The signal strength for this cell network, either the RSSI or RSCP.
+
+ta
+    The timing advance value for this cell network.
+
+
+WiFi Fields
+-----------
+
+For ``wifi`` entries, the ``key`` field is required. The client must check the
+Wifi SSID for a ``_nomap`` suffix. Wifi networks with this suffix must not be
+submitted to the server.
+
+Most devices will only report the WiFi frequency or the WiFi channel,
+but not both. The service will accept both if they are provided,
+but you can include only one or omit both fields.
+
+key **(required)**
+    The ``key`` is the BSSID of the WiFi network. So for example
+    a valid key would look similar to ``01:23:45:67:89:ab``.
+
+    The client must check the WiFi SSID for a ``_nomap`` suffix. WiFi networks
+    with this suffix must not be submitted to the server.
+
+    WiFi networks with a hidden SSID should not be submitted to the server
+    either.
+
+age
+    The number of milliseconds since this network was last detected.
+
+frequency
+    The frequency in MHz of the channel over which the client is
+    communicating with the access point.
+
+channel
+    The channel is a number specified by the IEEE which represents a
+    small band of frequencies.
+
+signal
+    The received signal strength (RSSI) in dBm, typically in the range of
+    -51 to -113.
+
+signalToNoiseRatio
+    The current signal to noise ratio measured in dB.
+
+ssid
+    The SSID of the Wifi network. Wifi networks with a SSID ending in
+    ``_nomap`` must not be collected.
+
+Here's an example of a valid WiFi record:
+
+.. code-block:: javascript
+
+    {
+        "key": "01:23:45:67:89:ab",
+        "age": 1500,
+        "channel": 11,
+        "frequency": 2412,
+        "signal": -51,
+        "signalToNoiseRatio": 37
+    }
 
 
 Response


### PR DESCRIPTION
When I removed the deprecated `/v1/search/` API endpoint code and documentation, I didn't realize the documentation for the `/v1/submit/` API endpoint referred to it for the field definitions.

This adds the field definitions to the `/v1/submit/` API endpoint.