### PR TITLE
Investigate occasional test failure in the locate API

### DIFF
--- a/ichnaea/api/locate/tests/__init__.py
+++ b/ichnaea/api/locate/tests/__init__.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Use pytest rich asserts in a file that doesn't match test_* pattern
+pytest.register_assert_rewrite("ichnaea.api.locate.tests.base")

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -171,6 +171,7 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
         ]
 
     def test_blue_seen(self, app, data_queues, session):
+        self.check_queue(data_queues, 0)
         blue = BlueShardFactory()
         offset = 0.00002
         blues = [blue, BlueShardFactory(lat=blue.lat + offset)]

--- a/ichnaea/api/submit/tests/__init__.py
+++ b/ichnaea/api/submit/tests/__init__.py
@@ -1,4 +1,4 @@
 import pytest
 
 # Use pytest rich asserts in a file that doesn't match test_* pattern
-pytest.register_assert_rewrite("ichnaea.api.locate.tests.base")
+pytest.register_assert_rewrite("ichnaea.api.submit.tests.base")

--- a/ichnaea/api/submit/tests/__init__.py
+++ b/ichnaea/api/submit/tests/__init__.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Use pytest rich asserts in a file that doesn't match test_* pattern
+pytest.register_assert_rewrite("ichnaea.api.locate.tests.base")


### PR DESCRIPTION
Issue #921 tracks a test that occasionally fails (1-2 times a week) with no relevant code changes. This PR makes two changes:

* Use ``pytest`` rich ``assert`` in ``ichnaea/api/locate/tests/base.py`` and ``ichnaea/api/submit/tests/base.py``. This will tell us how many items have been added to the ``update_incoming``, which is expected to be empty. The shared testing code in these files has been skipped because they are named ``base.py`` rather than ``test_base.py`` or ``base_test.py``. This is a smaller change than renaming the files, and avoids confusion with ``ichnaea/models/tests/test_base.py``.
* Confirm that the data queue is empty at the start of the test, so that we know whether there is a test setup issue or the API view is queuing the report for further processing.

