### PR TITLE
Re-add monitor queue size task

### DIFF
--- a/ichnaea/data/tasks.py
+++ b/ichnaea/data/tasks.py
@@ -74,6 +74,17 @@ def monitor_api_users(self):
 @celery_app.task(
     base=BaseTask,
     bind=True,
+    queue="celery_monitor",
+    expires=57,
+    _schedule=timedelta(seconds=60),
+)
+def monitor_queue_size(self):
+    monitor.QueueSize(self)()
+
+
+@celery_app.task(
+    base=BaseTask,
+    bind=True,
     queue="celery_reports",
     _countdown=2,
     expires=20,

--- a/ichnaea/taskapp/config.py
+++ b/ichnaea/taskapp/config.py
@@ -102,11 +102,10 @@ def init_worker(
 
     celery_app.geoip_db = configure_geoip(raven_client=raven_client, _client=_geoip_db)
 
-    # configure data queues
-    celery_app.all_queues = all_queues = set([q.name for q in TASK_QUEUES])
-
+    # configure data queues and build set of all queues
+    all_queues = set([q.name for q in TASK_QUEUES])
     celery_app.data_queues = data_queues = configure_data(redis_client)
-    all_queues = all_queues.union(
+    celery_app.all_queues = all_queues.union(
         set([queue.key for queue in data_queues.values() if queue.key])
     )
 


### PR DESCRIPTION
This re-adds the monitor queue size task. As MLS handles larger loads, the data queues can back up and if we're not able to see them, we can't do anything about it.

Fixes #947.