### PR TITLE
Test, fix cell area region algorithm when cell regions are None

### DIFF
--- a/ichnaea/data/area.py
+++ b/ichnaea/data/area.py
@@ -44,7 +44,9 @@ class CellAreaUpdater(object):
                 grouped_regions[reg] += 1
             max_count = max(grouped_regions.values())
             max_regions = sorted(
-                [k for k, v in grouped_regions.items() if v == max_count]
+                [k for k, v in grouped_regions.items() if v == max_count],
+                # Emulate Python 2.6, where None is sortable and first
+                key=lambda item: item or "",
             )
             # If we get a tie here, randomly choose the first.
             region = max_regions[0]

--- a/ichnaea/data/tests/test_area.py
+++ b/ichnaea/data/tests/test_area.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+import pytest
+
 from ichnaea.data.tasks import update_cellarea
 from ichnaea.models import area_id, encode_cellarea, CellArea, Radio
 from ichnaea.tests.factories import CellAreaFactory, CellShardFactory
@@ -213,3 +215,79 @@ class TestArea(object):
 
         area = session.query(self.area_model).one()
         assert area.region == "PR"
+
+    def test_region_all_none(self, celery, session):
+        """If all cell regions are None, the area region is None."""
+
+        # Sardinia, in Mediterranean, not identified as part of Italy
+        cell = self.cell_factory(
+            radio=Radio.wcdma,
+            mcc=204,
+            mnc=4,
+            lac=35051,
+            cid=1018429,
+            lat=40.18,
+            lon=9.59,
+            radius=10,
+            region=None,
+        )
+        assert cell.region is None
+        cell2 = self.cell_factory(
+            radio=cell.radio,
+            mcc=cell.mcc,
+            mnc=cell.mnc,
+            lac=cell.lac,
+            cid=cell.cid + 1,
+            lat=cell.lat + 0.1,
+            lon=cell.lon + 0.1,
+            radius=10,
+            region=None,
+        )
+        assert cell2.region is None
+        session.flush()
+
+        self.area_queue(celery).enqueue([area_id(cell)])
+        self.task.delay().get()
+
+        area = session.query(self.area_model).one()
+        assert area.region is None
+
+    @pytest.mark.xfail(reason="Raises TypeError", strict=True)
+    def test_region_null_tied(self, celery, session):
+        """If an equal number of cells have region=None, the area is None."""
+
+        # Bornholm, an island in the Baltic sea, not identified as part of Denmark
+        cell = self.cell_factory(
+            radio=Radio.wcdma,
+            mcc=204,
+            mnc=175,
+            lac=1515,
+            cid=13241603,
+            lat=55.115,
+            lon=14.88,
+            radius=10,
+            region=None,
+        )
+        assert cell.region is None
+
+        # Reeuwijk, Netherlands
+        self.cell_factory(
+            radio=Radio.wcdma,
+            mcc=cell.mcc,
+            mnc=cell.mnc,
+            lac=cell.lac,
+            cid=cell.cid + 2,
+            lat=52.056,
+            lon=4.733,
+            radius=10,
+            region="NL",
+        )
+        session.flush()
+
+        self.area_queue(celery).enqueue([area_id(cell)])
+        # FIXME: Raises exception while sorting
+        # TypeError: '<' not supported between instances of 'str' and 'NoneType'
+        self.task.delay().get()
+
+        area = session.query(self.area_model).one()
+        assert area.region is None

--- a/ichnaea/data/tests/test_area.py
+++ b/ichnaea/data/tests/test_area.py
@@ -1,7 +1,5 @@
 from datetime import timedelta
 
-import pytest
-
 from ichnaea.data.tasks import update_cellarea
 from ichnaea.models import area_id, encode_cellarea, CellArea, Radio
 from ichnaea.tests.factories import CellAreaFactory, CellShardFactory
@@ -252,7 +250,6 @@ class TestArea(object):
         area = session.query(self.area_model).one()
         assert area.region is None
 
-    @pytest.mark.xfail(reason="Raises TypeError", strict=True)
     def test_region_null_tied(self, celery, session):
         """If an equal number of cells have region=None, the area is None."""
 
@@ -285,8 +282,6 @@ class TestArea(object):
         session.flush()
 
         self.area_queue(celery).enqueue([area_id(cell)])
-        # FIXME: Raises exception while sorting
-        # TypeError: '<' not supported between instances of 'str' and 'NoneType'
         self.task.delay().get()
 
         area = session.query(self.area_model).one()


### PR DESCRIPTION
When importing the full cell export, a ``TypeError`` is raised when creating a cell area for some cell groups, due to changes in Python 3.x around comparing to ``None``. This PR avoids the ``TypeError`` and makes the code work like it did in Python 2.6.

In Python 2.6, you can sort ``None`` versus strings, and ``None`` is always less than a string:

```python
>>> sorted(['c', 'a', 'b', '', None])
[None, '', 'a', 'b', 'c']
```

In Python 3.7, it is a ``TypeError`` to compare ``None`` and other values:
```python
>>> sorted(['c', 'a', 'b', '', None])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

This can happen when the ``CellAreaUpdater`` is trying to determine the region for a group of cells with mixed regions, which may include ``None`` in cases where the geocoder can't determine the region. This happens in the dev environment for certain islands in Europe, such as [Sardinia](https://en.m.wikipedia.org/wiki/Sardinia) (a region of Italy) or [Bornholm](https://en.m.wikipedia.org/wiki/Bornholm) (a region of Denmark). It is possible the licensed MaxMindDB is more detailed, but this would still happen in the case of cell towers erroneously located in the ocean. 

This PR adds a test for all the cell regions being ``None`` (the cell area region is also ``None``), and if there is a tie between ``None`` and another region. This second test fails, raising a ``TypeError``, until the code changes that set the cell area region to ``None``, in the same way as Python 2.x sorting would work.