### PR TITLE
Add alembic heads to /__heartbeat__

### DIFF
--- a/ichnaea/webapp/monitor.py
+++ b/ichnaea/webapp/monitor.py
@@ -21,7 +21,19 @@ def _check_timed(ping_function):
 
 def check_database(request):
     """Check that the database is available for a simple query."""
-    return _check_timed(lambda: ping_session(request.db_session))
+    data = _check_timed(lambda: ping_session(request.db_session))
+    if data["up"]:
+        current_heads = [
+            row[0]
+            for row in request.db_session.execute(
+                "select version_num from alembic_version"
+            )
+        ]
+        alembic_version = ",".join(sorted(current_heads))
+    else:
+        alembic_version = "unknown"
+    data["alembic_version"] = alembic_version
+    return data
 
 
 def check_geoip(request):

--- a/ichnaea/webapp/tests.py
+++ b/ichnaea/webapp/tests.py
@@ -93,7 +93,11 @@ class TestHeartbeatErrors(object):
     def test_database(self, broken_app):
         res = broken_app.get("/__heartbeat__", status=503)
         assert res.content_type == "application/json"
-        assert res.json["database"] == {"up": False, "time": 0}
+        assert res.json["database"] == {
+            "up": False,
+            "time": 0,
+            "alembic_version": "unknown",
+        }
         assert res.headers["Access-Control-Allow-Origin"] == "*"
         assert res.headers["Access-Control-Max-Age"] == "2592000"
 


### PR DESCRIPTION
This adds the alembic heads to `/__hearbeat__`. This lets us see what the
current heads are in a server environment.

Fixes #956