### PR TITLE
Split counter and timer metrics

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -25,7 +25,7 @@ Metric Name                      Type    Tags
 `data.batch.upload`_             counter key
 `data.export.batch`_             counter key
 `data.export.upload`_            counter key, status
-`data.export.upload`_            timer   key
+`data.export.upload.timing`_     timer   key
 `data.observation.drop`_         counter type, key
 `data.observation.insert`_       counter type
 `data.observation.upload`_       counter type, key
@@ -384,6 +384,7 @@ Along the way several counters measure the steps involved:
 
 .. _data.export.batch:
 .. _data.export.upload:
+.. _data.export.upload.timing:
 
 Data Pipeline Export Metrics
 ----------------------------
@@ -395,7 +396,7 @@ targets. We keep metrics about how those individual export targets perform.
 
     Count the number of batches sent to the export target.
 
-``data.export.upload#key:<export_key>`` : timer
+``data.export.upload.timing#key:<export_key>`` : timer
 
     Track how long the upload operation took per export target.
 

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -46,7 +46,7 @@ Metric Name                      Type    Tags
 `queue`_                         gauge   queue
 `region.request`_                counter key, path
 `request`_                       counter path, method, status
-`request`_                       timer   path, method
+`request.timing`_                timer   path, method
 `submit.request`_                counter key, path
 `submit.user`_                   gauge   key, interval
 `task`_                          timer   task
@@ -468,12 +468,13 @@ paths referring to API endpoints. Logging them for unknown and invalid
 paths would overwhelm the system with all the random paths the friendly
 Internet bot army sends along.
 
+.. _request.timing:
 
 HTTP Timers
 -----------
 
 In addition to the HTTP counters, every legitimate, routed request
-emits a ``request#path:<path>,method:<method>`` timer.
+emits a ``request.timing#path:<path>,method:<method>`` timer.
 
 These timers have the same structure as the HTTP counters, except they
 do not have the response code tag.

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -36,8 +36,8 @@ Metric Name                      Type    Tags
 `data.station.new`_              counter type
 `datamaps`_                      timer   func, count
 `locate.fallback.cache`_         counter fallback_name, status
-`locate.fallback.lookup_timing`_ timer   fallback_name, status
-`locate.fallback.lookup_count`_  counter fallback_name, status
+`locate.fallback.lookup`_        counter fallback_name, status
+`locate.fallback.lookup.timing`_ timer   fallback_name, status
 `locate.query`_                  counter key, region, geoip, blue, cell, wifi
 `locate.request`_                counter key, path
 `locate.result`_                 counter key, region, accuracy, status, source, fallback_allowed
@@ -244,8 +244,8 @@ All of this combined might lead to a tagged metric like:
 ``locate.source#key:test,region:de,source:geoip,accuracy:low,status:hit``
 
 .. _locate.fallback.cache:
-.. _locate.fallback.lookup_count:
-.. _locate.fallback.lookup_timing:
+.. _locate.fallback.lookup:
+.. _locate.fallback.lookup.timing:
 
 API Fallback Source Metrics
 ---------------------------
@@ -267,11 +267,11 @@ The fallback name tag specifies which fallback service is used.
     If the cached values didn't agree on a consistent position,
     a `inconsistent` status is used.
 
-``locate.fallback.lookup_timing#fallback_name:<fallback_name>`` : timer
+``locate.fallback.lookup.timing#fallback_name:<fallback_name>`` : timer
 
     Measures the time it takes to do each outbound network request.
 
-``locate.fallback.lookup_count#fallback_name:<fallback_name>,status:<code>`` : counter
+``locate.fallback.lookup#fallback_name:<fallback_name>,status:<code>`` : counter
 
     Counts the HTTP response codes for all outbound requests. There
     is one counter per HTTP response code, for example `200`.

--- a/ichnaea/api/locate/fallback.py
+++ b/ichnaea/api/locate/fallback.py
@@ -596,11 +596,11 @@ class FallbackPositionSource(PositionSource):
         try:
             fallback_tag = "fallback_name:%s" % (query.api_key.fallback_name or "none")
 
-            with METRICS.timer("locate.fallback.lookup_timing", tags=[fallback_tag]):
+            with METRICS.timer("locate.fallback.lookup.timing", tags=[fallback_tag]):
                 response = outbound_call(query, outbound)
 
             METRICS.incr(
-                "locate.fallback.lookup_count",
+                "locate.fallback.lookup",
                 tags=[fallback_tag, "status:" + str(response.status_code)],
             )
 

--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -295,7 +295,7 @@ class CommonLocateTest(BaseLocateTest):
             tags=[self.metric_path, "method:get", "status:200"],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:get"]
+            "timing", "request.timing", tags=[self.metric_path, "method:get"]
         )
 
     def test_options(self, app):
@@ -334,7 +334,7 @@ class CommonLocateTest(BaseLocateTest):
             tags=[self.metric_path, "method:post", "status:200"],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
         if self.apikey_metrics:
             assert metricsmock.has_record(
@@ -526,7 +526,7 @@ class CommonPositionTest(BaseLocateTest):
             ],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
 
     def test_cell_not_found(self, app, data_queues, metricsmock):
@@ -585,7 +585,7 @@ class CommonPositionTest(BaseLocateTest):
             ],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
 
     def test_cell_invalid_lac(self, app, data_queues):
@@ -846,7 +846,7 @@ class CommonPositionTest(BaseLocateTest):
             ],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
 
     def test_ip_fallback_disabled(self, app, data_queues, metricsmock):
@@ -870,7 +870,7 @@ class CommonPositionTest(BaseLocateTest):
             tags=[self.metric_path, "key:test"],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
 
     def test_fallback(self, app, session, metricsmock):
@@ -958,7 +958,7 @@ class CommonPositionTest(BaseLocateTest):
             ],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
 
     def test_fallback_used_with_geoip(self, app, session, metricsmock):
@@ -1017,7 +1017,7 @@ class CommonPositionTest(BaseLocateTest):
             ],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
 
     def test_store_sample(self, app, data_queues, session):

--- a/ichnaea/api/locate/tests/test_fallback.py
+++ b/ichnaea/api/locate/tests/test_fallback.py
@@ -863,7 +863,7 @@ class BaseFallbackTest(object):
             tags=[self.fallback_tag, "status:miss"],
         )
         assert metricsmock.has_record(
-            "timing", "locate.fallback.lookup_timing", tags=[self.fallback_tag]
+            "timing", "locate.fallback.lookup.timing", tags=[self.fallback_tag]
         )
 
     def test_cache_empty_result(
@@ -892,7 +892,7 @@ class BaseFallbackTest(object):
             )
             assert metricsmock.has_record(
                 "incr",
-                "locate.fallback.lookup_count",
+                "locate.fallback.lookup",
                 value=1,
                 tags=[self.fallback_tag, "status:%s" % self.fallback_not_found_status],
             )
@@ -982,7 +982,7 @@ class TestDefaultFallback(BaseFallbackTest, BaseSourceTest):
         raven.check([("HTTPError", 1)])
         assert metricsmock.has_record(
             "incr",
-            "locate.fallback.lookup_count",
+            "locate.fallback.lookup",
             value=1,
             tags=[self.fallback_tag, "status:403"],
         )
@@ -1007,7 +1007,7 @@ class TestDefaultFallback(BaseFallbackTest, BaseSourceTest):
         raven.check([("HTTPError", 0)])
         assert metricsmock.has_record(
             "incr",
-            "locate.fallback.lookup_count",
+            "locate.fallback.lookup",
             value=1,
             tags=[self.fallback_tag, "status:404"],
         )
@@ -1027,12 +1027,12 @@ class TestDefaultFallback(BaseFallbackTest, BaseSourceTest):
         raven.check([("HTTPError", 1)])
         assert metricsmock.has_record(
             "incr",
-            "locate.fallback.lookup_count",
+            "locate.fallback.lookup",
             value=1,
             tags=[self.fallback_tag, "status:500"],
         )
         assert metricsmock.has_record(
-            "timing", "locate.fallback.lookup_timing", tags=[self.fallback_tag]
+            "timing", "locate.fallback.lookup.timing", tags=[self.fallback_tag]
         )
 
     def test_api_key_disallows(self, geoip_db, http_session, session, source):
@@ -1253,12 +1253,12 @@ class TestDefaultFallback(BaseFallbackTest, BaseSourceTest):
             )
             assert metricsmock.has_record(
                 "incr",
-                "locate.fallback.lookup_count",
+                "locate.fallback.lookup",
                 value=1,
                 tags=["fallback_name:fall", "status:200"],
             )
             assert metricsmock.has_record(
-                "timing", "locate.fallback.lookup_timing", tags=["fallback_name:fall"]
+                "timing", "locate.fallback.lookup.timing", tags=["fallback_name:fall"]
             )
             metricsmock.clear_records()
 

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -232,7 +232,7 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
             ],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
         items = data_queues["update_incoming"].dequeue()
         assert items == [
@@ -342,7 +342,7 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
             ],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
         items = data_queues["update_incoming"].dequeue()
         assert items == [
@@ -499,7 +499,7 @@ class TestError(LocateV1Base, BaseLocateTest):
             tags=[self.metric_path, "method:post", "status:200"],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
         if self.apikey_metrics:
             assert metricsmock.has_record(

--- a/ichnaea/api/locate/tests/test_region_v1.py
+++ b/ichnaea/api/locate/tests/test_region_v1.py
@@ -48,7 +48,7 @@ class TestView(RegionBase, CommonLocateTest):
             tags=[self.metric_path, "method:post", "status:200"],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
 
     def test_geoip_miss(self, app, data_queues, metricsmock):
@@ -61,7 +61,7 @@ class TestView(RegionBase, CommonLocateTest):
             tags=[self.metric_path, "method:post", "status:404"],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
 
     def test_incomplete_request(self, app, data_queues):

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -160,7 +160,7 @@ class BaseSubmitTest(object):
             tags=[self.metric_path, "key:test"],
         )
         assert metricsmock.has_record(
-            "timing", "request", tags=[self.metric_path, "method:post"]
+            "timing", "request.timing", tags=[self.metric_path, "method:post"]
         )
         today = util.utcnow().date()
         assert [k.decode("ascii") for k in redis.keys("apiuser:*")] == [

--- a/ichnaea/content/tests/test_views.py
+++ b/ichnaea/content/tests/test_views.py
@@ -111,9 +111,11 @@ class TestFunctionalContent(object):
         assert metricsmock.has_record(
             "incr", "request", value=1, tags=["path:map", "method:get", "status:200"]
         )
-        assert metricsmock.has_record("timing", "request", tags=["path:", "method:get"])
         assert metricsmock.has_record(
-            "timing", "request", tags=["path:map", "method:get"]
+            "timing", "request.timing", tags=["path:", "method:get"]
+        )
+        assert metricsmock.has_record(
+            "timing", "request.timing", tags=["path:map", "method:get"]
         )
 
     @config_override(ASSET_BUCKET="bucket", ASSET_URL="http://127.0.0.1:9/foo")

--- a/ichnaea/data/export.py
+++ b/ichnaea/data/export.py
@@ -125,7 +125,7 @@ class ReportExporter(object):
         success = False
         for i in range(self._retries):
             try:
-                with METRICS.timer("data.export.upload", tags=self.stats_tags):
+                with METRICS.timer("data.export.upload.timing", tags=self.stats_tags):
                     self.send(queue_items)
 
                 success = True

--- a/ichnaea/data/tests/test_export.py
+++ b/ichnaea/data/tests/test_export.py
@@ -199,7 +199,9 @@ class TestGeosubmit(BaseExportTest):
         assert metricsmock.has_record(
             "incr", "data.export.upload", value=1, tags=["key:test", "status:200"]
         )
-        assert metricsmock.has_record("timing", "data.export.upload", tags=["key:test"])
+        assert metricsmock.has_record(
+            "timing", "data.export.upload.timing", tags=["key:test"]
+        )
 
 
 class TestS3(BaseExportTest):
@@ -287,7 +289,7 @@ class TestS3(BaseExportTest):
         assert (
             len(
                 metricsmock.filter_records(
-                    "timing", "data.export.upload", tags=["key:backup"]
+                    "timing", "data.export.upload.timing", tags=["key:backup"]
                 )
             )
             == 4

--- a/ichnaea/log.py
+++ b/ichnaea/log.py
@@ -142,7 +142,7 @@ def log_tween_factory(handler, registry):
 
         def timer_send():
             duration = int(round((time.time() - start) * 1000))
-            METRICS.timing("request", duration, tags=statsd_tags)
+            METRICS.timing("request.timing", duration, tags=statsd_tags)
 
         def counter_send(status_code):
             METRICS.incr("request", tags=statsd_tags + ["status:%s" % status_code])


### PR DESCRIPTION
This PR creates new metrics for timing values, so that we are not using the same metric name for a counter and a timer:

* ``data.export.upload`` → ``data.export.upload.timing``
* ``request`` → ``request.timing``

The counters continue sending to the original names, ``data.export.upload`` and ``request``.

This is the fix to #960 that requires the least code changes. For consistency, I also changed two metrics to use the same naming convention:

* ``locate.fallback.lookup_timing`` → ``locate.fallback.lookup.timing``
* ``locate.fallback.lookup_count`` → ``locate.fallback.lookup``

This is not the only possible naming scheme, and I'm open to suggestions for other ones.