### PR TITLE
Improve webapp startup debugging

### DIFF
--- a/docker/run_web.sh
+++ b/docker/run_web.sh
@@ -37,6 +37,9 @@ GUNICORN_LOGLEVEL=${GUNICORN_LOGLEVEL:-"info"}
 
 LOCAL_DEV_ENV=${LOCAL_DEV_ENV:-"False"}
 
+# Make sure the app can load; this will route out some of the possible "can't
+# start" scenarios
+python ../ichnaea/webapp/app.py --check
 
 if [ "${LOCAL_DEV_ENV}" == "True" ]; then
     echo "*****************************************************************************"

--- a/docker/run_web.sh
+++ b/docker/run_web.sh
@@ -39,7 +39,7 @@ LOCAL_DEV_ENV=${LOCAL_DEV_ENV:-"False"}
 
 # Make sure the app can load; this will route out some of the possible "can't
 # start" scenarios
-python ../ichnaea/webapp/app.py --check
+python /app/ichnaea/webapp/app.py --check
 
 if [ "${LOCAL_DEV_ENV}" == "True" ]; then
     echo "*****************************************************************************"

--- a/ichnaea/webapp/app.py
+++ b/ichnaea/webapp/app.py
@@ -1,8 +1,15 @@
 """
 Holds global web application state and the WSGI handler.
+
+You can run this script for a one-process webapp.
+
+Further, you can pass in ``--check`` which will create the app and then exit
+making it easier to suss out startup and configuration issues.
+
 """
 
 import logging
+import sys
 
 from waitress import serve
 
@@ -66,4 +73,9 @@ def log_access_factory(wsgi_app):
 
 
 if __name__ == "__main__":
-    serve(log_access_factory(main(ping_connections=True)), host="0.0.0.0", port=8000)
+    if "--check" in sys.argv:
+        main(ping_connections=False)
+    else:
+        serve(
+            log_access_factory(main(ping_connections=True)), host="0.0.0.0", port=8000
+        )


### PR DESCRIPTION
This improves the ability to debug the webapp startup in server
environments where startup issues are masked by gunicorn running the
webapp in a separate worker process. Now when the webapp container is
started, it runs a "check" to see if things can start up, and then
proceeds to run the webapp in gunicorn.

This helps fix issue #967.