### PR TITLE
Fix sentry reporting to use git sha for release

### DIFF
--- a/ichnaea/log.py
+++ b/ichnaea/log.py
@@ -89,7 +89,8 @@ def configure_raven(transport=None, _client=None):
 
     dsn = settings("sentry_dsn")
     klass = DebugRavenClient if not dsn else RavenClient
-    release = version_info()["tag"]
+    info = version_info()
+    release = info.get("version") or info.get("commit") or "unknown"
     client = klass(dsn=dsn, transport=transport, release=release)
     return client
 

--- a/version.json
+++ b/version.json
@@ -1,7 +1,6 @@
 {
-    "build": null,
-    "commit": "HEAD",
     "source": "https://github.com/mozilla/ichnaea",
-    "tag": "master",
-    "version": "dev"
+    "version": "unknown",
+    "commit": "HEAD",
+    "build": "unknown"
 }


### PR DESCRIPTION
If there's no tag, use the git commit as the release in sentry
reporting. This makes it easier to figure out bugs when we're
auto-deploying to stage when things land in the master branch.

Part of issue #963.