### PR TITLE
Remove "tag" from /__version__ data

### DIFF
--- a/ichnaea/util.py
+++ b/ichnaea/util.py
@@ -82,10 +82,6 @@ def version_info():
                 info = json.load(fp)
             except json.JsonDecodeException:
                 pass
-
-    info["build"] = info.get("build", None)
-    info["commit"] = info.get("commit", None)
-    info["tag"] = info.get("tag", None)
     return info
 
 

--- a/ichnaea/webapp/tests.py
+++ b/ichnaea/webapp/tests.py
@@ -166,7 +166,7 @@ class TestVersion(object):
         response = app.get("/__version__", status=200)
         assert response.content_type == "application/json"
         data = response.json
-        assert set(data.keys()) == set(["build", "commit", "source", "tag", "version"])
+        assert set(data.keys()) == set(["build", "commit", "source", "version"])
         assert data["source"] == "https://github.com/mozilla/ichnaea"
 
 


### PR DESCRIPTION
Dockerflow doesn't have a "tag" key, so there shouldn't be one in `/__version__`.

Fixes #980