### PR TITLE
Change "umts" to "wcdma" in models docstring

### DIFF
--- a/ichnaea/models/cell.py
+++ b/ichnaea/models/cell.py
@@ -74,7 +74,7 @@ Example:
 .. code-block:: javascript
 
     {
-        "radio": "umts",
+        "radio": "wcdma",
         "mcc": 123,
         "mnc": 123,
         "lac": 12345,


### PR DESCRIPTION
"umts" is the deprecated name for WCDMA stations. This brings the JSON sample in line with the surrounding documentation.

This addresses some of #989.