### PR TITLE
Make it clearer that wcdma is alias for umts

### DIFF
--- a/ichnaea/models/constants.py
+++ b/ichnaea/models/constants.py
@@ -16,8 +16,9 @@ class Radio(IntEnum):
 
     gsm = 0
     cdma = 1
-    wcdma = 2
-    umts = 2
+    # wcdma is the preferred name for this radio type, matches Google's API
+    # umts is the original, deprecated name, still used in the public export
+    wcdma = umts = 2
     lte = 3
 
 


### PR DESCRIPTION
``wcdma`` is the preferred name for ``umts``. This is the remaining task to fix #989.

I also considered removing instance of ``Radio.umts`` from the codebase. This would be less than an hour of work, and could be done instead of this change.