### PR TITLE
Enable build-on-tag in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,6 @@
 version: 2
 jobs:
   build:
-    branches:
-        ignore:
-            # Old feature branch
-            - 1.5.x
-            # Generated docs hosted on GitHub
-            - gh-pages
-            # 2015 experiment to use ReadTheDocs
-            - readthedocs
     docker:
       - image: mozilla/cidockerbases:docker-latest
     working_directory: /

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,3 +113,14 @@ jobs:
                 fi
               fi
 
+workflows:
+  version: 2
+  #
+  # workflow jobs are _not_ run in tag builds by default, so we have to enable that.
+  # see: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
+  build-test-push:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/


### PR DESCRIPTION
CircleCI doesn't run builds on new tags by default. This enables that.