### PR TITLE
bug 1600706: change update_incoming batch size from 100 to 500

### DIFF
--- a/ichnaea/taskapp/config.py
+++ b/ichnaea/taskapp/config.py
@@ -43,7 +43,7 @@ def configure_data(redis_client):
     data_queues = {
         # *_incoming need to be the exact same as in webapp.config
         "update_incoming": DataQueue(
-            "update_incoming", redis_client, batch=100, compress=True
+            "update_incoming", redis_client, batch=500, compress=True
         )
     }
     for key in ("update_cellarea",):


### PR DESCRIPTION
This will cause a single celery task to process 500 rather than 100. Overall, this will reduce the amount of bookkeeping done per `update_incoming` item. The mean time for executing an `update_incoming`
task is pretty small compared to the other tasks, so this seems like a safe try.