### PR TITLE
Replace sync_session fixture with session

### DIFF
--- a/ichnaea/conftest.py
+++ b/ichnaea/conftest.py
@@ -196,25 +196,6 @@ def session(db):
 
 
 @pytest.fixture(scope="function")
-def sync_session(db):
-    with db.engine.connect() as conn:
-        with conn.begin() as trans:
-            db.session_factory.configure(bind=conn)
-            session = db.session()
-
-            # Set the global session context for factory-boy.
-            SESSION["default"] = session
-            yield session
-            del SESSION["default"]
-
-            trans.rollback()
-            session.close()
-            db.session_factory.configure(bind=db.engine)
-
-    API_CACHE.clear()
-
-
-@pytest.fixture(scope="function")
 def session_tracker(session):
     """
     This install an event handler into the active session, which

--- a/ichnaea/scripts/tests/test_datamap.py
+++ b/ichnaea/scripts/tests/test_datamap.py
@@ -20,7 +20,7 @@ class TestMap(object):
         for name in ("1,0", "meta"):
             assert os.path.isfile(os.path.join(path, name))
 
-    def test_files(self, sync_session):
+    def test_files(self, session):
         today = util.utcnow().date()
         rows = [
             dict(time=today, lat=12.345, lon=12.345),
@@ -32,8 +32,8 @@ class TestMap(object):
             data = DataMap.shard_model(lat, lon)(
                 grid=(lat, lon), created=row["time"], modified=row["time"]
             )
-            sync_session.add(data)
-        sync_session.flush()
+            session.add(data)
+        session.flush()
 
         lines = []
         rows = 0
@@ -47,9 +47,7 @@ class TestMap(object):
             for shard_id, shard in DataMap.shards().items():
                 filename = "map_%s.csv.gz" % shard_id
                 filepath = os.path.join(temp_dir, filename)
-                result = export_file(
-                    filepath, shard.__tablename__, _session=sync_session
-                )
+                result = export_file(filepath, shard.__tablename__, _session=session)
 
                 if not result:
                     assert not os.path.isfile(filepath)

--- a/ichnaea/scripts/tests/test_dump.py
+++ b/ichnaea/scripts/tests/test_dump.py
@@ -65,21 +65,21 @@ class TestDump(object):
     def _mac_keys(self, networks):
         return [network.mac for network in networks]
 
-    def test_blue(self, sync_session):
+    def test_blue(self, session):
         # Add one network outside the desired area.
         BlueShardFactory(lat=46.5743, lon=6.3532, region="FR")
         blues = BlueShardFactory.create_batch(1)
-        sync_session.flush()
-        self._export(sync_session, "blue", self._mac_keys(blues), restrict=True)
+        session.flush()
+        self._export(session, "blue", self._mac_keys(blues), restrict=True)
 
-    def test_cell(self, sync_session):
+    def test_cell(self, session):
         cells = CellShardFactory.create_batch(2)
         # Add one far away network, with no area restriction.
         cells.append(CellShardFactory(lat=46.5743, lon=6.3532, region="FR"))
-        sync_session.flush()
-        self._export(sync_session, "cell", self._cell_keys(cells))
+        session.flush()
+        self._export(session, "cell", self._cell_keys(cells))
 
-    def test_wifi(self, sync_session):
+    def test_wifi(self, session):
         wifis = WifiShardFactory.create_batch(5)
-        sync_session.flush()
-        self._export(sync_session, "wifi", self._mac_keys(wifis))
+        session.flush()
+        self._export(session, "wifi", self._mac_keys(wifis))


### PR DESCRIPTION
After removing the alternate database drivers, the two session fixtures are identical, and tests using the ``sync_session`` fixture work just as well with the more common ``session`` fixture.