### PR TITLE
Fix StationUpdate deadlock handler and track handled deadlocks

### DIFF
--- a/docs/algo/observations.rst
+++ b/docs/algo/observations.rst
@@ -78,6 +78,9 @@ to queues like ``update_wifi_0`` and ``update_blue_a``.
 These per-shard queues are processed when a large enough batch is accumulated,
 or when the queue is about to expire.  Batching increases the chances that
 there will be several observations for a station processed in the same chunk.
+It also increases the chance that two station updating threads will try to
+update the same station. This causes a deadlock, which restarts one of the
+tasks and is tracked with the metric ``data.station.dberror``.
 
 Observation Weight
 ==================

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -33,6 +33,7 @@ Metric Name                      Type    Tags
 `data.report.upload`_            counter key
 `data.station.blocklist`_        counter type
 `data.station.confirm`_          counter type
+`data.station.dberror`_          counter type, errno
 `data.station.new`_              counter type
 `datamaps`_                      timer   func, count
 `locate.fallback.cache`_         counter fallback_name, status
@@ -285,6 +286,7 @@ The fallback name tag specifies which fallback service is used.
 .. _data.station.confirm:
 .. _data.station.blocklist:
 .. _data.station.new:
+.. _data.station.dberror:
 
 Data Pipeline Metrics
 ---------------------
@@ -381,6 +383,18 @@ Along the way several counters measure the steps involved:
 
     Count the number of Bluetooth, cell or WiFi :term:`station` that were
     discovered for the first time.
+
+``data.station.dberror#type:<type>,errno:<errno>``: counters
+
+    Count the number of retryable database errors.  ``type`` is ``blue``,
+    ``cell``, or ``wifi``, and ``errno`` is the error number, which can be
+    found on the `MySQL Server Error Reference`_.
+
+    Retryable database errors, like a deadlock (``1213``) cause the station
+    updating task to sleep and start over. Other database errors are not
+    counted, but instead halt the task and are recorded in Sentry.
+
+.. _`MySQL Server Error Reference`: https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html
 
 .. _data.export.batch:
 .. _data.export.upload:

--- a/ichnaea/data/station.py
+++ b/ichnaea/data/station.py
@@ -4,9 +4,9 @@ import time
 
 import markus
 import numpy
-from pymysql.err import InternalError as PyMysqlInternalError
+from pymysql.err import MySQLError
 from pymysql.constants.ER import LOCK_WAIT_TIMEOUT, LOCK_DEADLOCK
-from sqlalchemy.exc import InternalError as SQLInternalError
+from sqlalchemy.exc import SQLAlchemyError
 
 from geocalc import circle_radius, distance
 from ichnaea.geocode import GEOCODER
@@ -568,9 +568,9 @@ class StationUpdater(object):
                         )
 
                 success = True
-            except SQLInternalError as exc:
+            except SQLAlchemyError as exc:
                 if (
-                    isinstance(exc.orig, PyMysqlInternalError)
+                    isinstance(exc.orig, MySQLError)
                     and exc.orig.args[0] in self._retriable
                 ):
                     success = False

--- a/ichnaea/data/station.py
+++ b/ichnaea/data/station.py
@@ -574,6 +574,14 @@ class StationUpdater(object):
                     and exc.orig.args[0] in self._retriable
                 ):
                     success = False
+                    METRICS.incr(
+                        "data.station.dberror",
+                        1,
+                        tags=[
+                            "type:%s" % self.station_type,
+                            "errno:%s" % exc.orig.args[0],
+                        ],
+                    )
                     time.sleep(self._retry_wait * (i ** 2 + 1))
                 else:
                     raise

--- a/ichnaea/data/tests/test_station.py
+++ b/ichnaea/data/tests/test_station.py
@@ -151,6 +151,12 @@ class TestDatabaseErrors(BaseStationTest):
                 )
                 == 1
             )
+            assert metricsmock.has_record(
+                "incr",
+                "data.station.dberror",
+                value=1,
+                tags=["type:cell", "errno:%s" % LOCK_WAIT_TIMEOUT],
+            )
         finally:
             CellUpdater._retry_wait = orig_wait
             session.execute(text("drop table %s;" % cell.__tablename__))
@@ -221,6 +227,12 @@ class TestDatabaseErrors(BaseStationTest):
             "incr", "data.station.confirm", value=1, tags=["type:cell"]
         )
         assert metricsmock.has_record("timing", "task", tags=["task:data.update_cell"])
+        assert metricsmock.has_record(
+            "incr",
+            "data.station.dberror",
+            value=1,
+            tags=["type:cell", "errno:%s" % errno],
+        )
 
 
 class StationTest(BaseStationTest):

--- a/ichnaea/data/tests/test_station.py
+++ b/ichnaea/data/tests/test_station.py
@@ -97,6 +97,8 @@ class TestDatabaseErrors(BaseStationTest):
         )
         session.add(cell)
         session.commit()
+        # TODO: Find a more elegant way to do this
+        db.tests_task_use_savepoint = True
 
         error = errclass(errno, errmsg)
         wrapped = InterfaceError.instance(
@@ -111,6 +113,8 @@ class TestDatabaseErrors(BaseStationTest):
             self._queue_and_update(celery, [obs], update_cell)
             assert CellUpdater.add_area_update.call_count == 2
             sleepy.assert_called_once_with(1)
+
+        del db.tests_task_use_savepoint
 
         cells = session.query(shard).all()
         assert len(cells) == 1

--- a/ichnaea/data/tests/test_station.py
+++ b/ichnaea/data/tests/test_station.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
-from pymysql.err import InternalError, MySQLError
+from pymysql.err import InternalError, MySQLError, OperationalError
 from pymysql.constants.ER import LOCK_DEADLOCK, LOCK_WAIT_TIMEOUT
 from pytz import UTC
 from sqlalchemy import text
@@ -159,8 +159,7 @@ class TestDatabaseErrors(BaseStationTest):
         "errclass,errno,errmsg",
         (
             (
-                # This was an InternalError before PyMySQL 0.9.0
-                InternalError,
+                OperationalError,
                 LOCK_DEADLOCK,
                 "Deadlock found when trying to get lock; try restarting transaction",
             ),

--- a/ichnaea/db.py
+++ b/ichnaea/db.py
@@ -83,7 +83,10 @@ def db_worker_session(database, commit=True):
     """
     try:
         session = database.session()
-        if commit:
+        # When running in a test that is expecting to issue a rollback,
+        # add a savepoint so that test fixtures are not also rolled back.
+        # TODO: Find a more elegant way to do this.
+        if getattr(database, "tests_task_use_savepoint", False):
             session.begin_nested()
         yield session
         if commit:

--- a/ichnaea/db.py
+++ b/ichnaea/db.py
@@ -83,6 +83,8 @@ def db_worker_session(database, commit=True):
     """
     try:
         session = database.session()
+        if commit:
+            session.begin_nested()
         yield session
         if commit:
             session.commit()


### PR DESCRIPTION
In [PyMySQL 0.9.0](https://github.com/PyMySQL/PyMySQL/blob/master/CHANGELOG#L39), ``LOCK_DEADLOCK`` changed from an internal error to an operational error. This also changes the SQLAlchemy error class used to wrap it. This broke the deadlock handler, and we started to get many more of these when the latest code went to production.

This PR updates the handler to only look at the MySQL error code, and be more flexible about the error class used to report it. It also increments a metric ``data.station.dberror``, to allow us to track how handled deadlocks are affected by other data pipeline changes. I also added some tests to cover this behaviour, that may have caught this change.

I struggled with some weirdness around testing code that sends a ``ROLLBACK``, such as this code when detecting any database error. Because the same database connection is used in tests and in the code being tested, the ``ROLLBACK`` was causing test rows to be rolled back as well, changing the database for the next round. For an existing test, this changed an "UPDATE" operation into an "INSERT" operation, when the ``ROLLBACK`` removed the cell from the database.

I've fixed this by using ``session.begin_nested()`` in the task session, to create a nested transaction. I tried some other things, such as creating a new database connection, and registering an event handler as suggested by the [SQLAlchemy docs](https://docs.sqlalchemy.org/en/13/orm/session_transaction.html?highlight=test#joining-a-session-into-an-external-transaction-such-as-for-test-suites), but this was the most reliable method. With the way it is written, it will also use nested transactions in production, which should be safe but might have other effects. If we're worried about that, I can try to restrict the nested transaction to tests.

I also added a second mode to the `raven` test fixture. Previously, it asserted that no messages were sent with raven during the test in the fixture tear down. That is still the default, but now setting `raven.expect_message = True` will change to asserting that at least one message was sent.

This should fix #991, but I believe there are more changes to avoid deadlocks in the first place.