### PR TITLE
Encode binary IDs in base64 for numpy

### DIFF
--- a/ichnaea/api/locate/cell.py
+++ b/ichnaea/api/locate/cell.py
@@ -1,5 +1,6 @@
 """Search implementation using a cell database."""
 
+from base64 import b64decode
 from collections import defaultdict
 import math
 
@@ -42,7 +43,7 @@ NETWORK_DTYPE = numpy.dtype(
         ("age", numpy.int32),
         ("signalStrength", numpy.int32),
         ("score", numpy.double),
-        ("id", "S11"),
+        ("id_b64", "S16"),
         ("seen_today", numpy.bool),
     ]
 )
@@ -79,7 +80,7 @@ def cluster_cells(cells, lookups, min_age=0):
                         obs_data[cell.cellid][0],
                         obs_data[cell.cellid][1],
                         station_score(cell, now),
-                        encode_cellid(*cell.cellid),
+                        encode_cellid(*cell.cellid, codec="base64"),
                         bool(cell.last_seen is not None and cell.last_seen >= today),
                     )
                     for cell in area_cells
@@ -118,7 +119,7 @@ def cluster_areas(areas, lookups, min_age=0):
                         obs_data[area.areaid][0],
                         obs_data[area.areaid][1],
                         area_score(area, now),
-                        encode_cellarea(*area.areaid),
+                        encode_cellarea(*area.areaid, codec="base64"),
                         bool(area.last_seen is not None and area.last_seen >= today),
                     )
                 ],
@@ -284,8 +285,8 @@ class CellPositionMixin(object):
                     )
 
                     used_networks = [
-                        ("cell", bytes(id_), bool(seen_today))
-                        for id_, seen_today in cluster[["id", "seen_today"]]
+                        ("cell", b64decode(id_b64), bool(seen_today))
+                        for id_b64, seen_today in cluster[["id_b64", "seen_today"]]
                     ]
 
                     results.add(
@@ -312,8 +313,8 @@ class CellPositionMixin(object):
                     )
 
                     used_networks = [
-                        ("area", bytes(id_), bool(seen_today))
-                        for id_, seen_today in cluster[["id", "seen_today"]]
+                        ("area", b64decode(id_b64), bool(seen_today))
+                        for id_b64, seen_today in cluster[["id_b64", "seen_today"]]
                     ]
 
                     results.add(

--- a/ichnaea/api/locate/internal.py
+++ b/ichnaea/api/locate/internal.py
@@ -56,10 +56,10 @@ class InternalPositionSource(
             return
 
         result_networks = {"area": set(), "blue": set(), "cell": set(), "wifi": set()}
-        for network in best_result.used_networks:
-            if network[2]:
+        for net_type, net_id, seen_today in best_result.used_networks:
+            if seen_today:
                 # only add network if it was last_seen today
-                result_networks[network[0]].add(network[1])
+                result_networks[net_type].add(net_id)
 
         if result_networks == query.networks():
             # don't store queries, based exclusively on data,

--- a/ichnaea/api/locate/mac.py
+++ b/ichnaea/api/locate/mac.py
@@ -1,5 +1,6 @@
 """Search implementation using a mac based source."""
 
+from base64 import b64decode
 from collections import defaultdict
 import itertools
 import math
@@ -22,7 +23,7 @@ NETWORK_DTYPE = numpy.dtype(
         ("age", numpy.int32),
         ("signalStrength", numpy.int32),
         ("score", numpy.double),
-        ("mac", "S6"),
+        ("mac_b64", "S8"),
         ("seen_today", numpy.bool),
     ]
 )
@@ -55,7 +56,7 @@ def cluster_networks(
                 obs_data[model.mac][0],
                 obs_data[model.mac][1],
                 station_score(model, now),
-                encode_mac(model.mac),
+                encode_mac(model.mac, codec="base64"),
                 bool(model.last_seen is not None and model.last_seen >= today),
             )
             for model in models
@@ -181,8 +182,8 @@ def aggregate_cluster_position(
     score = float(cluster["score"].sum())
 
     used_networks = [
-        (data_type, bytes(mac), bool(seen_today))
-        for mac, seen_today in sample[["mac", "seen_today"]]
+        (data_type, b64decode(mac_b64), bool(seen_today))
+        for mac_b64, seen_today in sample[["mac_b64", "seen_today"]]
     ]
 
     return result_type(

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -170,13 +170,17 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
             }
         ]
 
-    def test_blue_seen(self, app, data_queues, session):
+    @pytest.mark.parametrize("mac", ["a82067491500", "a82067491501"])
+    def test_blue_seen(self, app, data_queues, session, mac):
         """If a query contains no new data, it is not queued for further processing.
 
-        This fails occasionally, see issue #921.
+        Due to an issue with truncating bytestrings in a numpy array (numpy
+        issue 8089), addresses that end in '00' were once detected as new
+        stations.
         """
+
         self.check_queue(data_queues, 0)
-        blue = BlueShardFactory()
+        blue = BlueShardFactory(mac=mac)
         offset = 0.00002
         blues = [blue, BlueShardFactory(lat=blue.lat + offset)]
         session.flush()


### PR DESCRIPTION
numpy strips trailing ``NULL`` characters (``0x00``) from byte strings ([numpy issue 8089](https://github.com/numpy/numpy/issues/8089)). This can cause stations to be detected as new stations, requiring further processing.

Instead of storing the raw binary IDs in the numpy array, store a base64-encoded string, and decode it before passing back to ``InternalPositionSource``.

Fixes #921, which was randomly hitting this issue with Bluetooth stations.