### PR TITLE
Use a shared session for tests

### DIFF
--- a/ichnaea/data/tests/test_station.py
+++ b/ichnaea/data/tests/test_station.py
@@ -97,8 +97,7 @@ class TestDatabaseErrors(BaseStationTest):
         )
         session.add(cell)
         session.commit()
-        # TODO: Find a more elegant way to do this
-        db.tests_task_use_savepoint = True
+        session.begin_nested()  # Protect test cell from task rollback
 
         error = errclass(errno, errmsg)
         wrapped = InterfaceError.instance(
@@ -113,8 +112,6 @@ class TestDatabaseErrors(BaseStationTest):
             self._queue_and_update(celery, [obs], update_cell)
             assert CellUpdater.add_area_update.call_count == 2
             sleepy.assert_called_once_with(1)
-
-        del db.tests_task_use_savepoint
 
         cells = session.query(shard).all()
         assert len(cells) == 1

--- a/ichnaea/scripts/tests/test_dump.py
+++ b/ichnaea/scripts/tests/test_dump.py
@@ -10,8 +10,8 @@ def _dump_nothing(datatype, session, filename, lat=None, lon=None, radius=None):
     return 0
 
 
-class TestDump(object):
-    def test_main(self, db):
+class TestDump:
+    def test_main(self, db, session):
         assert (
             dump.main(
                 [


### PR DESCRIPTION
When running tests, use ``scoped_session`` to ensure that test code, app code, and task code all work with the same session. This allows ``session.begin_nested()`` to be used when testing code that calls ``session.rollback()``. This is currently one test, the recently refactored test for deadlocks in ``StationUpdater``, but more are expected as we add more deadlock handlers.

There are a few changes to tests when using a shared, thread-local session. The first is that ``session.close()`` should only be called once at the end of tests, rather than once for each provisioned session. The function-scoped ``session`` fixture handles closing the session, and a new function ``db.release_session(session)`` can be used instead of ``session.close()``.

Because the ``session`` fixture is in charge of session teardown, it must be included if a new session is provisioned by tested code, or else the session will remain allocated and cause an error in the next test that uses a session. If ``db.session()`` is called without the ``session`` fixture, an exception is raised, so that the correct test fails.

This is follow-on work for issue #991