### PR TITLE
Add shared session fixtures

### DIFF
--- a/ichnaea/data/tests/test_public.py
+++ b/ichnaea/data/tests/test_public.py
@@ -156,7 +156,7 @@ class TestExport(object):
 
 
 @pytest.fixture
-def cellarea_queue(redis_client):
+def cellarea_queue(redis_client, celery):
     """Return the DataQueue for updating CellAreas by ID."""
     return configure_data(redis_client)["update_cellarea"]
 


### PR DESCRIPTION
*Note*: This is an alternate implementation of PR #1012. Notes about the differences are at the bottom. This is follow-on work for issue #991.
*Note 2*: Reworked and force pushed, new PR summary.

Previously, all tests used independent sessions bound to a transaction. This fails when a test needs to setup data in the test, and then tests code that issues a transaction rollback. This results in the setup data being rolled back as well. This is currently one test, the recently refactored test for deadlocks in ``StationUpdater``, but more are expected as we add more deadlock handlers.

The Database class now takes a ``shared=True`` keyword. When set, SQLAlchemy's ``scoped_session`` is used to return a thread-local session when ``db.session()`` is called. For these shared sessions, ``session.close()`` should be called once, for example in ``db.close()``, instead of by each caller of ``db.session()``. A new method ``db.release_session(session)`` helps callers release sessions the right way.

Move the existing database fixtures to new ones that make it explicit what kind of sessions are returned:

* ``db`` → ``db_independent_session``
* ``session`` → ``independent_session``
* ``global_app`` → ``app_independent_session``

Add some new fixtures that use a thread-local session, so that the test code, app, and celery can work in the same session:

* ``db_shared_session``
* ``shared_session``
* ``app_shared_session``
* ``celery_shared_session``

These function-scoped fixtures now return the shared session variants if ``db_shared_session`` or ``shared_session`` is requested, and the traditional independent sessions by default:

* ``db``
* ``session``
* ``app``
* ``celery``

Re-using these names means that most tests do not need changing to get the default independent session implementation. A few require additional fixtures to ensure session-scoped fixtures are setup.

This is the fixture alternative mentioned in https://github.com/mozilla/ichnaea/pull/1012#issuecomment-565611638. It was close enough that I wanted to finish it off, and it has grown on me since last week.

I then continued the work to use session-scoped fixtures when possible, so that there isn't (as much of) a speed penalty to using the just-in-time fixtures.