### PR TITLE
StationUpdater: Use backoff.on_exception decorator

### DIFF
--- a/ichnaea/data/tests/test_station.py
+++ b/ichnaea/data/tests/test_station.py
@@ -116,10 +116,10 @@ class TestDatabaseErrors(BaseStationTest):
         )
         with mock.patch.object(
             CellUpdater, "add_area_update", side_effect=[wrapped, None]
-        ), mock.patch("ichnaea.data.station.time.sleep") as sleepy:
+        ), mock.patch("backoff._sync.time.sleep") as sleepy:
             self._queue_and_update(celery, [obs], update_cell)
             assert CellUpdater.add_area_update.call_count == 2
-            sleepy.assert_called_once_with(1)
+            sleepy.assert_called_once()
 
         cells = session.query(shard).all()
         assert len(cells) == 1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -219,3 +219,6 @@ dockerflow==2019.10.0 \
 markus==2.1.0 \
     --hash=sha256:3408818d4d78ca0f4085c6ea32b02f4b3d2a2520b169ddec3167b50f0b7c700d \
     --hash=sha256:bfa276c69b25006e37449eed447bc27105bf6f26c9ca27d01ddefbd1077b44ea
+backoff==1.10.0 \
+    --hash=sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd \
+    --hash=sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4


### PR DESCRIPTION
Add new dependency [backoff](https://github.com/litl/backoff), which provides a ``backoff.on_exception`` decorator that can be used to handle retrying for exceptions. This may help standardize the retry logic before we roll it out to other updater tasks.

I wasn't able to use ``backoff.on_exception`` as a traditional decorator, because the ``METRICS`` call needs access to both ``self.station_type`` and the error number from the exception. If I dropped the metrics call, or made it a counter without tags, then it could be simplified down to a decorator.

This is follow-on work for issue #991.