### PR TITLE
StationUpdater: Use SELECT ... WITH UPDATE

### DIFF
--- a/ichnaea/data/station.py
+++ b/ichnaea/data/station.py
@@ -629,7 +629,9 @@ class StationUpdater(object):
 
 class MacUpdater(StationUpdater):
     def query_shard(self, session, shard, keys):
-        return (session.query(shard).filter(shard.mac.in_(keys))).all()
+        return (
+            (session.query(shard).filter(shard.mac.in_(keys))).with_for_update().all()
+        )
 
 
 class BlueUpdater(MacUpdater):
@@ -662,7 +664,11 @@ class CellUpdater(StationUpdater):
     stat_station_key = StatKey.unique_cell
 
     def query_shard(self, session, shard, keys):
-        return (session.query(shard).filter(shard.cellid.in_(keys))).all()
+        return (
+            (session.query(shard).filter(shard.cellid.in_(keys)))
+            .with_for_update()
+            .all()
+        )
 
     def add_area_update(self, updated_areas, key):
         updated_areas.add(encode_cellarea(*decode_cellid(key)[:4]))


### PR DESCRIPTION
When ``SELECT``ing station rows for updating, use ``WITH UPDATE`` to acquire a row lock. This may result in more lock timeouts, but less ``StaleDataError``s in stage and production. If this helps reduce issue #990, then we can roll out a similar change to the cell area and datamap update tasks.