### PR TITLE
bug 1607906: Remove string handling from encode/decode_gzip

### DIFF
--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -438,7 +438,7 @@ class CommonLocateTest(BaseLocateTest):
         wifis = WifiShardFactory.build_batch(2)
         query = self.model_query(wifis=wifis)
 
-        body = util.encode_gzip(json.dumps(query))
+        body = util.encode_gzip(json.dumps(query).encode())
         headers = {"Content-Encoding": "gzip"}
         res = self._call(
             app, body=body, headers=headers, method="post", status=self.not_found.code

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -40,7 +40,7 @@ class BaseSubmitTest(object):
     def test_gzip(self, app, celery):
         cell, query = self._one_cell_query()
         data = {"items": [query]}
-        body = util.encode_gzip(dumps(data))
+        body = util.encode_gzip(dumps(data).encode())
         headers = {"Content-Encoding": "gzip"}
         res = app.post(
             self.url,

--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -90,7 +90,7 @@ class BaseAPIView(BaseView):
         if self.request.headers.get("Content-Encoding") == "gzip":
             # handle gzip self.request bodies
             try:
-                request_content = util.decode_gzip(self.request.body, encoding=None)
+                request_content = util.decode_gzip(self.request.body)
             except GZIPDecodeError as exc:
                 errors.append({"name": None, "description": repr(exc)})
 

--- a/ichnaea/data/export.py
+++ b/ichnaea/data/export.py
@@ -165,7 +165,9 @@ class GeosubmitExporter(ReportExporter):
 
         response = requests.post(
             self.config.url,
-            data=util.encode_gzip(json.dumps({"items": reports}), compresslevel=5),
+            data=util.encode_gzip(
+                json.dumps({"items": reports}).encode(), compresslevel=5
+            ),
             headers=headers,
             timeout=60.0,
         )
@@ -210,7 +212,9 @@ class S3Exporter(ReportExporter):
         obj_name += uuid.uuid1().hex + ".json.gz"
 
         try:
-            data = util.encode_gzip(json.dumps({"items": reports}), compresslevel=7)
+            data = util.encode_gzip(
+                json.dumps({"items": reports}).encode(), compresslevel=7
+            )
 
             s3 = boto3.resource("s3")
             bucket = s3.Bucket(bucketname)

--- a/ichnaea/queue.py
+++ b/ichnaea/queue.py
@@ -45,7 +45,7 @@ class DataQueue(object):
             result = pipe.execute()[0]
 
             if self.compress:
-                result = [util.decode_gzip(item, encoding=None) for item in result]
+                result = [util.decode_gzip(item) for item in result]
             if self.json:
                 result = [json.loads(item.decode("utf-8")) for item in result]
 
@@ -75,7 +75,7 @@ class DataQueue(object):
             items = [json.dumps(item).encode("utf-8") for item in items]
 
         if self.compress:
-            items = [util.encode_gzip(item, encoding=None) for item in items]
+            items = [util.encode_gzip(item) for item in items]
 
         if pipe is not None:
             self._push(pipe, items, batch)

--- a/ichnaea/tests/test_util.py
+++ b/ichnaea/tests/test_util.py
@@ -20,29 +20,18 @@ class TestUtil(object):
         assert now.tzinfo == UTC
 
     def test_encode_gzip(self):
-        data = util.encode_gzip("foo")
-        assert data[:4] == self.gzip_foo[:4]
-        assert data[-13:] == self.gzip_foo[-13:]
-
-    def test_encode_gzip_bytes(self):
         data = util.encode_gzip(b"foo")
+        # Test around the 4-byte timestamp
         assert data[:4] == self.gzip_foo[:4]
-        assert data[-13:] == self.gzip_foo[-13:]
+        assert data[8:] == self.gzip_foo[8:]
 
     def test_decode_gzip(self):
         data = util.decode_gzip(self.gzip_foo)
-        assert data == "foo"
+        assert data == b"foo"
 
     def test_roundtrip_gzip(self):
         data = util.decode_gzip(util.encode_gzip(b"foo"))
-        assert data == "foo"
-
-    def test_no_encoding(self):
-        data = util.encode_gzip(b"\x00ab", encoding=None)
-        assert isinstance(data, bytes)
-        result = util.decode_gzip(data, encoding=None)
-        assert isinstance(result, bytes)
-        assert result == b"\x00ab"
+        assert data == b"foo"
 
     def test_decode_gzip_error(self):
         with pytest.raises(GZIPDecodeError):

--- a/ichnaea/util.py
+++ b/ichnaea/util.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 from datetime import datetime
 import gzip
-from io import BytesIO
 from itertools import zip_longest
 import json
 import os
@@ -34,12 +33,7 @@ def gzip_open(filename, mode, compresslevel=6):
 
 def encode_gzip(data, compresslevel=6):
     """Encode the passed in data with gzip."""
-    out = BytesIO()
-    with gzip.GzipFile(
-        None, "wb", compresslevel=compresslevel, fileobj=out
-    ) as gzip_file:
-        gzip_file.write(data)
-    return out.getvalue()
+    return gzip.compress(data, compresslevel=compresslevel)
 
 
 def decode_gzip(data):
@@ -48,9 +42,7 @@ def decode_gzip(data):
     :raises: :exc:`~ichnaea.exceptions.GZIPDecodeError`
     """
     try:
-        with gzip.GzipFile(None, mode="rb", fileobj=BytesIO(data)) as gzip_file:
-            out = gzip_file.read()
-        return out
+        return gzip.decompress(data)
     except (IOError, OSError, EOFError, struct.error, zlib.error) as exc:
         raise GZIPDecodeError(repr(exc))
 

--- a/ichnaea/util.py
+++ b/ichnaea/util.py
@@ -32,10 +32,8 @@ def gzip_open(filename, mode, compresslevel=6):
             yield gzip_file
 
 
-def encode_gzip(data, compresslevel=6, encoding="utf-8"):
+def encode_gzip(data, compresslevel=6):
     """Encode the passed in data with gzip."""
-    if encoding and isinstance(data, str):
-        data = data.encode(encoding)
     out = BytesIO()
     with gzip.GzipFile(
         None, "wb", compresslevel=compresslevel, fileobj=out
@@ -44,16 +42,14 @@ def encode_gzip(data, compresslevel=6, encoding="utf-8"):
     return out.getvalue()
 
 
-def decode_gzip(data, encoding="utf-8"):
-    """Decode the bytes data and return a Unicode string.
+def decode_gzip(data):
+    """Return the gzip-decompressed bytes.
 
     :raises: :exc:`~ichnaea.exceptions.GZIPDecodeError`
     """
     try:
         with gzip.GzipFile(None, mode="rb", fileobj=BytesIO(data)) as gzip_file:
             out = gzip_file.read()
-        if encoding:
-            return out.decode(encoding)
         return out
     except (IOError, OSError, EOFError, struct.error, zlib.error) as exc:
         raise GZIPDecodeError(repr(exc))


### PR DESCRIPTION
For ``util.encode_gzip``, drop optional ``encoding`` parameter and require that the input is bytes. This simplifies half of the callers, and calling ``.encode()`` on the string data does the right thing for the rest.

For ``utils.decode_gzip``, drop the optional ``encoding`` parameter and return the decompressed bytes instead of a string decoded from UTF-8. This simplifies most callers, who were sending ``encoding=None`` to get this behavior.

Also, use Python 3.2's ``gzip.compress`` and ``gzip.decompress``, which take care of the details of feeding bytes through ``GzipFile``. However, errors in the bytes are still raised as if they come from a file, like ``gzip.BadGzipFile``, so the exception handler remains complex.