### PR TITLE
Expand lock retries and SELECT ... WITH UPDATE to cell area and datamap updates 

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -36,6 +36,7 @@ Metric Name                      Type    Tags
 `data.station.dberror`_          counter type, errno
 `data.station.new`_              counter type
 `datamaps`_                      timer   func, count
+`datamaps.dberror`_              counter errno
 `locate.fallback.cache`_         counter fallback_name, status
 `locate.fallback.lookup`_        counter fallback_name, status
 `locate.fallback.lookup.timing`_ timer   fallback_name, status
@@ -387,14 +388,13 @@ Along the way several counters measure the steps involved:
 ``data.station.dberror#type:<type>,errno:<errno>``: counters
 
     Count the number of retryable database errors.  ``type`` is ``blue``,
-    ``cell``, or ``wifi``, and ``errno`` is the error number, which can be
-    found on the `MySQL Server Error Reference`_.
+    ``cell``, ``cellarea``, or ``wifi``, and ``errno`` is the error number,
+    which can be found on the `MySQL Server Error Reference`_.
 
-    Retryable database errors, like a deadlock (``1213``) cause the station
-    updating task to sleep and start over. Other database errors are not
-    counted, but instead halt the task and are recorded in Sentry.
-
-.. _`MySQL Server Error Reference`: https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html
+    Retryable database errors, like a lock timeout (``1205``) or deadlock
+    (``1213``) cause the station updating task to sleep and start over.  Other
+    database errors are not counted, but instead halt the task and are recorded
+    in Sentry.
 
 .. _data.export.batch:
 .. _data.export.upload:
@@ -508,6 +508,7 @@ For example:
   - ``task#task:data.update_statcounter``
 
 .. _datamaps:
+.. _datamaps.dberror:
 
 Datamaps Timers
 ---------------
@@ -534,3 +535,16 @@ to monitor its operation.
 
     Pseudo-timers to track the number of CSV rows, Quadtree files and
     image tiles.
+
+
+``datamaps.dberror#errno:<errno>``: counter
+
+    Count the number of retryable database errors.  ``errno`` is the error
+    number, which can be found on the `MySQL Server Error Reference`_.
+
+    Retryable database errors, like a lock timeout (``1205``) or deadlock
+    (``1213``) cause the station updating task to sleep and start over.  Other
+    database errors are not counted, but instead halt the task and are recorded
+    in Sentry.
+
+.. _`MySQL Server Error Reference`: https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html

--- a/ichnaea/conftest.py
+++ b/ichnaea/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from unittest import mock
 import gc
 import warnings
 
@@ -510,3 +511,13 @@ def celery(request, global_celery, raven, redis):
         yield request.getfixturevalue("celery_shared_session")
     else:
         yield global_celery
+
+
+@pytest.fixture
+def backoff_sleep_mock():
+    """Mock backoff's time.sleep, so that test remain fast.
+
+    Useful when testing retry_on_mysql_lock_fail.
+    """
+    with mock.patch("backoff._sync.time.sleep") as mocked_sleep:
+        yield mocked_sleep

--- a/ichnaea/data/area.py
+++ b/ichnaea/data/area.py
@@ -115,7 +115,9 @@ class CellAreaUpdater(object):
                     self.area_table.c.num_cells,
                     self.area_table.c.last_seen,
                 ]
-            ).where(self.area_table.c.areaid == areaid)
+            )
+            .where(self.area_table.c.areaid == areaid)
+            .with_for_update()
         ).fetchone()
 
         cell_extremes = numpy.array(

--- a/ichnaea/data/datamap.py
+++ b/ichnaea/data/datamap.py
@@ -44,9 +44,9 @@ class DataMapUpdater(object):
         today = util.utcnow().date()
 
         rows = session.execute(
-            select([self.shard_table.c.grid, self.shard_table.c.modified]).where(
-                self.shard_table.c.grid.in_(grids)
-            )
+            select([self.shard_table.c.grid, self.shard_table.c.modified])
+            .where(self.shard_table.c.grid.in_(grids))
+            .with_for_update()
         ).fetchall()
 
         outdated = set()

--- a/ichnaea/tests/test_db.py
+++ b/ichnaea/tests/test_db.py
@@ -1,4 +1,14 @@
-class TestDatabase(object):
+"""Tests for database related functionality."""
+
+import pytest
+from pymysql.constants.ER import CONSTRAINT_FAILED, LOCK_WAIT_TIMEOUT, LOCK_DEADLOCK
+from pymysql.err import InternalError, MySQLError, OperationalError
+from sqlalchemy.exc import InterfaceError, StatementError
+
+from ichnaea.db import retry_on_mysql_lock_fail
+
+
+class TestDatabase:
     def test_constructor(self, db):
         assert db.engine.name == "mysql"
         assert db.engine.dialect.driver == "pymysql"
@@ -6,3 +16,133 @@ class TestDatabase(object):
     def test_table_creation(self, session):
         result = session.execute("select * from cell_gsm;")
         assert result.first() is None
+
+
+RETRIABLES = {
+    "deadlock": (
+        OperationalError,
+        LOCK_DEADLOCK,
+        "Deadlock found when trying to get lock; try restarting transaction",
+    ),
+    "wait-timeout": (
+        InternalError,
+        LOCK_WAIT_TIMEOUT,
+        "Lock wait timeout exceeded; try restarting transaction",
+    ),
+}
+
+
+class TestRetryOnMySQLLockFail:
+    """Test the retry_on_mysql_lock_fail decorator."""
+
+    def _raise_mysql_error(self, errclass, errno, errmsg):
+        """Raise a MySQL error wrapped by SQLAlchemy."""
+        error = errclass(errno, errmsg)
+        wrapped = InterfaceError.instance(
+            statement="SELECT COUNT(*) FROM table",
+            params={},
+            orig=error,
+            dbapi_base_err=MySQLError,
+        )
+        raise wrapped
+
+    @pytest.mark.parametrize(
+        "errclass,errno,errmsg", RETRIABLES.values(), ids=list(RETRIABLES.keys())
+    )
+    def test_retriable_exceptions(self, errclass, errno, errmsg, backoff_sleep_mock):
+        """The method is retried on a retriable exception."""
+        count = 0
+
+        @retry_on_mysql_lock_fail()
+        def raise_first_time():
+            nonlocal count
+            count += 1
+            if count < 2:
+                self._raise_mysql_error(errclass, errno, errmsg)
+
+        raise_first_time()
+        assert count == 2
+        assert backoff_sleep_mock.call_count == 1
+
+    @pytest.mark.parametrize(
+        "errclass,errno,errmsg", RETRIABLES.values(), ids=list(RETRIABLES.keys())
+    )
+    def test_retry_failure(self, errclass, errno, errmsg, backoff_sleep_mock):
+        """The retriable exception is raised after several retries."""
+        count = 0
+
+        @retry_on_mysql_lock_fail()
+        def keep_raising():
+            nonlocal count
+            count += 1
+            self._raise_mysql_error(errclass, errno, errmsg)
+
+        pytest.raises(StatementError, keep_raising)
+        assert count == 3
+        assert backoff_sleep_mock.call_count == 2
+
+    def test_raises_other_statement_error(self):
+        """Non-handled StatementErrors are raised."""
+
+        @retry_on_mysql_lock_fail()
+        def raise_other():
+            self._raise_mysql_error(
+                OperationalError,
+                CONSTRAINT_FAILED,
+                "CONSTRAINT `CONSTRAINT_1` failed for `table`.`field`",
+            )
+
+        pytest.raises(StatementError, raise_other)
+
+    def test_raises_other_exceptions(self):
+        """Non-handled exceptions are raised."""
+
+        @retry_on_mysql_lock_fail()
+        def raise_other():
+            raise RuntimeError("Something else happened.")
+
+        pytest.raises(RuntimeError, raise_other)
+
+    @pytest.mark.parametrize(
+        "errclass,errno,errmsg", RETRIABLES.values(), ids=list(RETRIABLES.keys())
+    )
+    def test_metric_increment(
+        self, errclass, errno, errmsg, backoff_sleep_mock, metricsmock
+    ):
+
+        count = 0
+
+        @retry_on_mysql_lock_fail(metric="dberror")
+        def raise_first_time():
+            nonlocal count
+            count += 1
+            if count < 2:
+                self._raise_mysql_error(errclass, errno, errmsg)
+
+        raise_first_time()
+        assert count == 2
+        assert backoff_sleep_mock.call_count == 1
+        expected_tags = [f"errno:{errno}"]
+        assert metricsmock.get_records() == [("incr", "dberror", 1, expected_tags)]
+
+    @pytest.mark.parametrize(
+        "errclass,errno,errmsg", RETRIABLES.values(), ids=list(RETRIABLES.keys())
+    )
+    def test_metric_increment_with_tags(
+        self, errclass, errno, errmsg, backoff_sleep_mock, metricsmock
+    ):
+
+        count = 0
+
+        @retry_on_mysql_lock_fail(metric="dberror", metric_tags=["weight:heavy"])
+        def raise_first_time():
+            nonlocal count
+            count += 1
+            if count < 2:
+                self._raise_mysql_error(errclass, errno, errmsg)
+
+        raise_first_time()
+        assert count == 2
+        assert backoff_sleep_mock.call_count == 1
+        expected_tags = [f"errno:{errno}", "weight:heavy"]
+        assert metricsmock.get_records() == [("incr", "dberror", 1, expected_tags)]


### PR DESCRIPTION
Move ``_retry_updates_on_mysql_lock_fail``  to ``retry_on_mysql_lock_fail`` in ``ichnaea.db``, move station-specific stuff to parameters, and implement as a standard decorator.

This makes it a little more awkward to use in ``StationUpdater``, but allows it to be expanded to cell area and datamap updating. This addresses issue #991.

The ``data.station.dberror`` metric may have tag ``type=cellarea`` for retryable
exceptions in ``CellAreaUpdater``, and a new metric ``datamaps.dberror`` is
incremented from ``DataMapUpdater``.

Add a ``WITH UPDATE`` clause to the ``SELECT`` for cell areas and datamaps, to avoid ``StaleDataErrors``s, and maybe turn some into deadlocks (which will now be retried). This addresses issue #990.