### PR TITLE
bug 1607906: re-write preprocess_request for detailed errors

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -126,8 +126,18 @@ error code:
             }],
             "code": 400,
             "message": "Parse Error"
+            "details": {
+                "decode": "JSONDecodeError('Expecting value: line 1 column 1 (char 0)')"
+            }
         }
     }
+
+The ``details`` item will be a mapping with the key ``"decode"`` or
+``"validation"``.  If the key is ``"decode"``, the value will be a string
+describing a fundamental decoding issue, such as failing to decompress gzip
+content, to convert to unicode from the declared charset, or to parse as JSON.
+If the key is ``"validation"``, the value will describe validation errors in
+the JSON payload.
 
 
 Service Error

--- a/ichnaea/api/exceptions.py
+++ b/ichnaea/api/exceptions.py
@@ -152,6 +152,17 @@ class ParseError(BaseAPIClientError):
     domain = "global"
     reason = "parseError"
     message = "Parse Error"
+    error_details = None
+
+    def __init__(self, details=None):
+        self.error_details = details
+        super().__init__()
+
+    def json_body(self):
+        content = super().json_body()
+        if self.error_details:
+            content["details"] = self.error_details
+        return content
 
 
 class ServiceUnavailable(BaseAPIServiceError):

--- a/ichnaea/api/exceptions.py
+++ b/ichnaea/api/exceptions.py
@@ -34,8 +34,7 @@ class JSONException(HTTPException):
     def __str__(self):
         return "<%s>: %s" % (self.__class__.__name__, self.code)
 
-    @classmethod
-    def json_body(cls):
+    def json_body(self):
         """A JSON representation of this response."""
         return {}
 
@@ -46,11 +45,6 @@ class UploadSuccess(JSONException):
     """
 
     code = 200
-
-    @classmethod
-    def json_body(cls):
-        """A JSON representation of this response."""
-        return {}
 
 
 class UploadSuccessV0(UploadSuccess):
@@ -74,16 +68,19 @@ class BaseAPIError(JSONException):
     reason = ""
     message = ""
 
-    @classmethod
-    def json_body(cls):
+    def json_body(self):
         """A JSON representation of this response."""
         return {
             "error": {
                 "errors": [
-                    {"domain": cls.domain, "reason": cls.reason, "message": cls.message}
+                    {
+                        "domain": self.domain,
+                        "reason": self.reason,
+                        "message": self.message,
+                    }
                 ],
-                "code": cls.code,
-                "message": cls.message,
+                "code": self.code,
+                "message": self.message,
             }
         }
 

--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -221,13 +221,13 @@ class BaseLocateTest(object):
                 del body["fallback"]
             assert body == self.ip_response
         elif status == "invalid_key":
-            assert response.json == InvalidAPIKey.json_body()
+            assert response.json == InvalidAPIKey().json_body()
         elif status == "not_found":
-            assert response.json == self.not_found.json_body()
+            assert response.json == self.not_found().json_body()
         elif status == "parse_error":
             assert response.json == ParseError(details).json_body()
         elif status == "limit_exceeded":
-            assert response.json == DailyLimitExceeded.json_body()
+            assert response.json == DailyLimitExceeded().json_body()
         if status != "ok":
             self.check_queue(data_queues, 0)
 

--- a/ichnaea/api/locate/tests/test_fallback.py
+++ b/ichnaea/api/locate/tests/test_fallback.py
@@ -828,7 +828,7 @@ class BaseFallbackTest(object):
 
     @property
     def fallback_not_found(self):
-        return LocationNotFound.json_body()
+        return LocationNotFound().json_body()
 
     def _check_success_fallbacks(self, request_json):
         assert "considerIp" not in request_json
@@ -996,7 +996,7 @@ class TestDefaultFallback(BaseFallbackTest, BaseSourceTest):
             mock_request.register_uri(
                 "POST",
                 requests_mock.ANY,
-                json=LocationNotFound.json_body(),
+                json=LocationNotFound().json_body(),
                 status_code=404,
             )
 

--- a/ichnaea/api/locate/views.py
+++ b/ichnaea/api/locate/views.py
@@ -15,7 +15,7 @@ class BaseLocateView(BaseAPIView):
     searcher = None
 
     def locate(self, api_key):
-        request_data, errors = self.preprocess_request()
+        request_data = self.preprocess_request()
 
         query = Query(
             fallback=request_data.get("fallbacks"),

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -124,7 +124,7 @@ class BaseSubmitTest(object):
 
         with mock.patch("ichnaea.queue.DataQueue.enqueue", mock_queue):
             res = self._post_one_cell(app, status=503)
-            assert res.json == ServiceUnavailable.json_body()
+            assert res.json == ServiceUnavailable().json_body()
 
         assert mock_queue.called
         raven.check([("ServiceUnavailable", 1)])

--- a/ichnaea/api/submit/tests/test_submit_v0.py
+++ b/ichnaea/api/submit/tests/test_submit_v0.py
@@ -280,12 +280,18 @@ class TestView(BaseSubmitTest):
         self._post(app, items)
         assert self.queue(celery).size() == batch
 
-    def test_error(self, app, celery, raven):
+    def test_error_not_dict(self, app, celery, raven):
         wifi = WifiShardFactory.build()
         res = app.post_json(
             "/v1/submit", [{"lat": wifi.lat, "lon": wifi.lon, "cell": []}], status=400
         )
-        assert res.json == ParseError.json_body()
+        detail = {
+            "": (
+                "\"[{'lat': 51.5, 'lon': -0.1, 'cell': []}]\" is not a mapping"
+                " type: Does not implement dict-like functionality."
+            )
+        }
+        assert res.json == ParseError({"validation": detail}).json_body()
 
     def test_error_missing_latlon(self, app, celery):
         wifi = WifiShardFactory.build()

--- a/ichnaea/api/submit/tests/test_submit_v2.py
+++ b/ichnaea/api/submit/tests/test_submit_v2.py
@@ -255,7 +255,7 @@ class TestView(BaseSubmitTest):
 
     def test_error(self, app, celery, raven):
         wifi = WifiShardFactory.build()
-        self._post(
+        response = self._post(
             app,
             [
                 {
@@ -265,6 +265,11 @@ class TestView(BaseSubmitTest):
             ],
             status=400,
         )
+        assert response.json["details"]["validation"] == {
+            "items.0.wifiAccessPoints.0.macAddress": (
+                "10 is not a string: {'macAddress': ''}"
+            )
+        }
         assert self.queue(celery).size() == 0
 
     def test_error_missing_latlon(self, app, celery):

--- a/ichnaea/api/submit/views.py
+++ b/ichnaea/api/submit/views.py
@@ -39,7 +39,7 @@ class BaseSubmitView(BaseAPIView):
         METRICS.incr("data.batch.upload", tags=tags)
 
     def submit(self, api_key):
-        request_data, errors = self.preprocess_request()
+        request_data = self.preprocess_request()
 
         if not request_data:
             # don't allow completely empty request

--- a/ichnaea/api/tests.py
+++ b/ichnaea/api/tests.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 import colander
@@ -114,13 +115,24 @@ class TestRenamingMapping(object):
 
 
 class TestExceptions(object):
-    def _check(self, error, status, json=True, content_type="application/json"):
-        response = Request.blank("/").get_response(error())
+    def _check(
+        self,
+        error,
+        status,
+        json=True,
+        content_type="application/json",
+        is_instance=False,
+    ):
+        if is_instance:
+            error_instance = error
+        else:
+            error_instance = error()
+        response = Request.blank("/").get_response(error_instance)
         if content_type:
             assert response.content_type == content_type
         assert response.status_code == status
         if json:
-            assert response.json == error.json_body()
+            assert response.json == error_instance.json_body()
         return response
 
     def test_str(self):
@@ -146,6 +158,13 @@ class TestExceptions(object):
         error = api_exceptions.ParseError
         response = self._check(error, 400)
         assert b"parseError" in response.body
+
+    def test_parse_error_details(self):
+        error = api_exceptions.ParseError(details=["Details of Error"])
+        response = self._check(error, 400, json=False, is_instance=True)
+        assert b"parseError" in response.body
+        content = json.loads(response.body.decode())
+        assert content["details"] == ["Details of Error"]
 
     def test_upload_success(self):
         error = api_exceptions.UploadSuccess

--- a/ichnaea/api/tests.py
+++ b/ichnaea/api/tests.py
@@ -115,64 +115,53 @@ class TestRenamingMapping(object):
 
 
 class TestExceptions(object):
-    def _check(
-        self,
-        error,
-        status,
-        json=True,
-        content_type="application/json",
-        is_instance=False,
-    ):
-        if is_instance:
-            error_instance = error
-        else:
-            error_instance = error()
-        response = Request.blank("/").get_response(error_instance)
+    def _check(self, error, status, json=True, content_type="application/json"):
+        response = Request.blank("/").get_response(error)
         if content_type:
             assert response.content_type == content_type
         assert response.status_code == status
         if json:
-            assert response.json == error_instance.json_body()
+            assert response.json == error.json_body()
         return response
 
     def test_str(self):
-        error = api_exceptions.LocationNotFound
-        assert str(error()) == "<LocationNotFound>: 404"
+        error = api_exceptions.LocationNotFound()
+        assert str(error) == "<LocationNotFound>: 404"
 
     def test_daily_limit(self):
-        error = api_exceptions.DailyLimitExceeded
+        error = api_exceptions.DailyLimitExceeded()
         response = self._check(error, 403)
         assert b"dailyLimitExceeded" in response.body
 
     def test_invalid_apikey(self):
-        error = api_exceptions.InvalidAPIKey
+        error = api_exceptions.InvalidAPIKey()
         response = self._check(error, 400)
         assert b"keyInvalid" in response.body
 
     def test_location_not_found(self):
-        error = api_exceptions.LocationNotFound
+        error = api_exceptions.LocationNotFound()
         response = self._check(error, 404)
         assert b"notFound" in response.body
 
     def test_parse_error(self):
-        error = api_exceptions.ParseError
+        error = api_exceptions.ParseError()
         response = self._check(error, 400)
         assert b"parseError" in response.body
 
     def test_parse_error_details(self):
         error = api_exceptions.ParseError(details=["Details of Error"])
-        response = self._check(error, 400, json=False, is_instance=True)
+        response = self._check(error, 400, json=False)
         assert b"parseError" in response.body
         content = json.loads(response.body.decode())
         assert content["details"] == ["Details of Error"]
 
     def test_upload_success(self):
-        error = api_exceptions.UploadSuccess
+        error = api_exceptions.UploadSuccess()
         response = self._check(error, 200)
         assert response.body == b"{}"
 
     def test_upload_success_v0(self):
-        error = api_exceptions.UploadSuccessV0
+        error = api_exceptions.UploadSuccessV0()
         response = self._check(error, 204, json=False, content_type=None)
         assert response.body == b""
 

--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -115,7 +115,7 @@ class BaseAPIView(BaseView):
         if request_content and errors:
             raise self.prepare_exception(ParseError())
 
-        return (validated_data, errors)
+        return validated_data
 
     def __call__(self):
         """Execute the view and return a response."""

--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -94,7 +94,11 @@ class BaseAPIView(BaseView):
             except GZIPDecodeError as exc:
                 errors.append({"name": None, "description": repr(exc)})
 
-        content = request_content.decode(self.request.charset)
+        content = ""
+        try:
+            content = request_content.decode(self.request.charset)
+        except UnicodeDecodeError as exc:
+            errors.append({"name": None, "description": repr(exc)})
 
         request_data = {}
         try:


### PR DESCRIPTION
PR #1028 unintentionally removed an exception handler for string decoding issues. Previously, bytes were decoded as part of ``json.loads``:

https://github.com/mozilla/ichnaea/blob/cc3d9f314110c4acb9af6161f9998b7f06490048/ichnaea/api/views.py#L106-L110

If decoding failed, a ``UnicodeDecodeError`` was raised, which is derived from ``ValueError``, so it was caught and handled.

In Python 3.8, ``json.loads`` no longer uses the `encoding` parameter, so bytes decoding was moved to a separate step, without a ``try``/``except`` block. Some callers have triggered this, raising a handful of exceptions in production (see [bug 1607906](https://bugzilla.mozilla.org/show_bug.cgi?id=1607906#c2)). The most common root cause appears to be sending a truncated gzip-compressed payload, which resulted in an unsuccessful decode of a compresses bytestring.

This PR makes a number of changes to ``preprocess_request`` to solve this issue:

* Add tests for truncated gzip-compressed content and badly encoded content
* Allow ``ParseError`` to take an optional ``details`` parameter at initialization, which is added to the response JSON. Expand the exception tests to test instances as well as exception classes.
* Add a ``detail`` section to the ``ParseError`` JSON, which gives the caller more information, so they can tell if it is a gzip, unicode, or JSON decoding error, or a payload validation error.
* Simplify the return value of ``preprocess_request``, since the ``error`` element of the tuple is unused.
   



