### PR TITLE
bug 1610015: Restrict CORS to API endpoints

### DIFF
--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -27,6 +27,8 @@ class BaseAPIView(BaseView):
     metric_path = None  # Dotted URL path, for example v1.submit.
     schema = None  # An instance of a colander schema to validate the data.
     view_type = None  # The type of view, for example submit or locate.
+    cors_origin = "*"  # Allow all CORS origins for API views
+    cors_max_age = 86400 * 30  # Cache preflight requests for 30 days.
 
     def __init__(self, request):
         super(BaseAPIView, self).__init__(request)

--- a/ichnaea/webapp/view.py
+++ b/ichnaea/webapp/view.py
@@ -15,8 +15,8 @@ class BaseView(object):
     """
 
     _cors_headers = None
-    cors_max_age = 86400 * 30  # Cache preflight requests for 30 days.
-    cors_origin = "*"  # Allowed CORS origins.
+    cors_max_age = 0  # Cache preflight requests, default omit
+    cors_origin = None  # Allowed CORS origins, default omit
     methods = ("GET", "HEAD", "POST")  # Supported HTTP methods.
     renderer = "json"  # The name of the renderer to use.
     route = None  # The url path for this view, e.g. `/hello`.


### PR DESCRIPTION
Restrict Cross-Origin Resource Sharing, via ``Access-Control-Allow-Origin`` header, to the API endpoints. Previously, CORS was allowed on all views. 

CORS for ``/v1/country`` was requested in November 2015 in https://github.com/mozilla/ichnaea/issues/468. This is appropriate for an API called from in-browser JavaScript from unknown sites, but it doesn't need to be applied to the homepage or other content pages.