### PR TITLE
bug 1613233: Drop reports with null positions

### DIFF
--- a/ichnaea/data/export.py
+++ b/ichnaea/data/export.py
@@ -329,7 +329,8 @@ class InternalTransform(object):
         cells = self._parse_list(item, report, self.cell_id, self.cell_map)
         wifis = self._parse_list(item, report, self.wifi_id, self.wifi_map)
 
-        gps_age = item.get("position", {}).get("age", 0)
+        position = item.get("position") or {}
+        gps_age = position.get("age", 0)
         timestamp = item.get("timestamp")
         if timestamp:
             # turn timestamp into GPS timestamp


### PR DESCRIPTION
In the ``InternalExporter``, ensure that a position of null/``None`` is dropped without an error. For other exporters, confirm that these reports are forwarded without errors.

In [v2/geosubmit](https://ichnaea.readthedocs.io/en/latest/api/geosubmit2.html), the position item is a dictionary that includes the latitude and longitude, position source, and other details. It is not
required by the geosubmit endpoints, and it is possible for clients to submit WiFi and other data without including a GPS-derived position.

This fixes [bug 1613233](https://bugzilla.mozilla.org/show_bug.cgi?id=1613233), where a null position was causing an exception to be raised.