### PR TITLE
bug 1616536: add geoip version to __heartbeat__

### DIFF
--- a/ichnaea/geoip.py
+++ b/ichnaea/geoip.py
@@ -454,6 +454,14 @@ class GeoIPWrapper(Reader):
         build_epoch = self.metadata().build_epoch
         return int(round((time.time() - build_epoch) / 86400, 0))
 
+    @property
+    def version(self):
+        """
+        :returns: The version of the database.
+        :rtype: int
+        """
+        return self.metadata().build_epoch
+
     def ping(self):
         """
         :returns: True if this is a real database with a valid db file.
@@ -573,6 +581,13 @@ class GeoIPNull(object):
         :returns: -1
         """
         return -1
+
+    @property
+    def version(self):
+        """
+        :returns: 1582121727
+        """
+        return 1582121727
 
     def close(self):
         pass

--- a/ichnaea/webapp/monitor.py
+++ b/ichnaea/webapp/monitor.py
@@ -40,6 +40,7 @@ def check_geoip(request):
     geoip_db = request.registry.geoip_db
     result = _check_timed(geoip_db.ping)
     result["age_in_days"] = geoip_db.age
+    result["version"] = geoip_db.version
     return result
 
 

--- a/ichnaea/webapp/tests.py
+++ b/ichnaea/webapp/tests.py
@@ -103,7 +103,12 @@ class TestHeartbeatErrors(object):
     def test_geoip(self, broken_app):
         res = broken_app.get("/__heartbeat__", status=503)
         assert res.content_type == "application/json"
-        assert res.json["geoip"] == {"up": False, "time": 0, "age_in_days": -1}
+        assert res.json["geoip"] == {
+            "up": False,
+            "time": 0,
+            "age_in_days": -1,
+            "version": 1582121727,
+        }
 
     def test_redis(self, broken_app):
         res = broken_app.get("/__heartbeat__", status=503)


### PR DESCRIPTION
This adds the maxmind db `build_epoch` to the `__heartbeat__` response as geoip version.

To test:

```
curl http://localhost:8000/__heartbeat__
```