### PR TITLE
bug 1616536: change format of maxmind db version in /__heartbeat__

### DIFF
--- a/ichnaea/geoip.py
+++ b/ichnaea/geoip.py
@@ -462,7 +462,7 @@ class GeoIPWrapper(Reader):
         :rtype: string as iso-8601 YYYY-MM-DDTMM:HH:SSZ
         """
         epoch = self.metadata().build_epoch
-        return datetime.datetime.fromtimestamp(epoch).isoformat() + "Z"
+        return datetime.datetime.fromtimestamp(epoch).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     def ping(self):
         """

--- a/ichnaea/geoip.py
+++ b/ichnaea/geoip.py
@@ -4,6 +4,7 @@ Helper functions and classes around GeoIP lookups, based on Maxmind's
 `geoip2 <https://pypi.python.org/pypi/geoip2>`_ Python packages.
 """
 
+import datetime
 import logging
 import time
 
@@ -458,9 +459,10 @@ class GeoIPWrapper(Reader):
     def version(self):
         """
         :returns: The version of the database.
-        :rtype: int
+        :rtype: string as iso-8601 YYYY-MM-DDTMM:HH:SSZ
         """
-        return self.metadata().build_epoch
+        epoch = self.metadata().build_epoch
+        return datetime.datetime.fromtimestamp(epoch).isoformat() + "Z"
 
     def ping(self):
         """
@@ -585,9 +587,9 @@ class GeoIPNull(object):
     @property
     def version(self):
         """
-        :returns: 1582121727
+        :returns: 2020-02-26T12:17:00Z
         """
-        return 1582121727
+        return "2020-02-26T12:17:00Z"
 
     def close(self):
         pass

--- a/ichnaea/webapp/tests.py
+++ b/ichnaea/webapp/tests.py
@@ -107,7 +107,7 @@ class TestHeartbeatErrors(object):
             "up": False,
             "time": 0,
             "age_in_days": -1,
-            "version": 1582121727,
+            "version": "2020-02-26T12:17:00Z",
         }
 
     def test_redis(self, broken_app):


### PR DESCRIPTION
The version is a seconds-since-epoch of the build. This changes it to a
`YYYY-MM-DDTHH:MM:SSZ` format which is what Telemetry uses.