### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -4,7 +4,9 @@ FROM node:8-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     bzip2 \
     git \
     make \

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -5,7 +5,6 @@ FROM node:8-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
-    apt-utils \
     ca-certificates \
     bzip2 \
     git \

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -5,7 +5,6 @@ FROM node:8-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
-    ca-certificates \
     bzip2 \
     git \
     make \


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is 

1.  Slow and in log it is showing because "apt-utils" not installed 

2. to avoid build to exits with error without having certificate