### PR TITLE
bug 1619789: add API key request instructions for Mozilla projects

### DIFF
--- a/ichnaea/content/templates/api.pt
+++ b/ichnaea/content/templates/api.pt
@@ -59,7 +59,13 @@
     </p>
 
     <p class="text-justified">
-        To obtain an API key, please
+        If you are a Mozilla employee, to obtain an API key, please
+        <a href="https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&amp;component=API%20Key&amp;groups=mozilla-employee-confidential&amp;op_sys=Unspecified&amp;product=Location&amp;rep_platform=Unspecified">
+            file an API key request bug in Bugzilla</a>.
+    </p>
+
+    <p class="text-justified">
+        If you are not a Mozilla employee, to obtain an API key, please
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSf2JaJm8V1l8TS_OiyjodkpYsagOhM1LNo_SmPDDAVKdmQg8A/viewform">
             fill out this form</a>. When filling out the form,
         please make sure to describe your use-case and intended use of


### PR DESCRIPTION
This adds a separate section for Mozilla projects because we have a different way for them to request API keys.