### PR TITLE
Update to CircleCI 2.1 format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:


### PR DESCRIPTION
Update from version 2.0 to 2.1. The main difference appears to be [pipelines](https://circleci.com/docs/2.0/build-processing/).