### PR TITLE
bug 1623470: Drop region tag from metrics

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -47,6 +47,8 @@ Metric Name                      Type    Tags
 `locate.user`_                   gauge   key, interval
 `queue`_                         gauge   queue
 `region.request`_                counter key, path
+`region.result`_                 counter key, region, accuracy, status, source, fallback_allowed
+`region.user`_                   gauge   key, interval
 `request`_                       counter path, method, status
 `request.timing`_                timer   path, method
 `submit.request`_                counter key, path
@@ -83,6 +85,7 @@ These metrics can help in deciding when to remove a deprecated API.
     and no (``none``) provided API keys.
 
 .. _locate.user:
+.. _region.user:
 .. _submit.user:
 
 API User Metrics
@@ -142,6 +145,7 @@ in it:
     number of valid :term:`stations` for each of the three.
 
 .. _locate.result:
+.. _region.result:
 
 API Result Metrics
 ------------------

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -40,14 +40,14 @@ Metric Name                      Type    Tags
 `locate.fallback.cache`_         counter fallback_name, status
 `locate.fallback.lookup`_        counter fallback_name, status
 `locate.fallback.lookup.timing`_ timer   fallback_name, status
-`locate.query`_                  counter key, region, geoip, blue, cell, wifi
+`locate.query`_                  counter key, geoip, blue, cell, wifi
 `locate.request`_                counter key, path
-`locate.result`_                 counter key, region, accuracy, status, source, fallback_allowed
-`locate.source`_                 counter key, region, accuracy, status, source
+`locate.result`_                 counter key, accuracy, status, source, fallback_allowed
+`locate.source`_                 counter key, accuracy, status, source
 `locate.user`_                   gauge   key, interval
 `queue`_                         gauge   queue
 `region.request`_                counter key, path
-`region.result`_                 counter key, region, accuracy, status, source, fallback_allowed
+`region.result`_                 counter key, accuracy, status, source, fallback_allowed
 `region.user`_                   gauge   key, interval
 `request`_                       counter path, method, status
 `request.timing`_                timer   path, method
@@ -115,17 +115,13 @@ API Query Metrics
 -----------------
 
 For each incoming API query we log metrics about the data contained in
-the query with the metric name and tags:
+the query with the metric name and tag:
 
-``<api_type>.query#key<apikey>,region:<region_code>`` : counter
+``<api_type>.query#key<apikey>`` : counter
 
 `api_type` describes the type of API being used, independent of the
 version number of the API. So `v1/country` gets logged as `region`
 and both `v1/search` and `v1/geolocate` get logged as `locate`.
-
-`region_code` is either a two-letter GENC region code like `de` or the
-special value `none` if the region of origin of the incoming request
-could not be determined.
 
 We extend the metric with additional tags based on the data contained
 in it:
@@ -144,6 +140,9 @@ in it:
     one blue, cell and wifi tag get added. The tags depend on the
     number of valid :term:`stations` for each of the three.
 
+.. versionchanged:: 2020.04.unreleased
+   Removed the ``region`` tag
+
 .. _locate.result:
 .. _region.result:
 
@@ -154,7 +153,7 @@ Similar to the API query metrics we also collect metrics about each
 result of an API query. This follows the same per API type and per
 region rules under the prefix / tag combination:
 
-``<api_type>.result#key:<apikey>,region:<region_code>``
+``<api_type>.result#key:<apikey>``
 
 The result metrics measure if we satisfied the incoming API query in
 the best possible fashion. Incoming queries can generally contain
@@ -233,6 +232,9 @@ to use the fallback source.
 
     The value is either `true` or `false`.
 
+.. versionchanged:: 2020.04.unreleased
+   Removed the ``region`` tag
+
 .. _locate.source:
 
 API Source Metrics
@@ -240,14 +242,17 @@ API Source Metrics
 
 In addition to the final API result, we also collect metrics about each
 individual data source we use to answer queries under the
-``<api_type>.source#key:<apikey>,region:<region_code>`` metric.
+``<api_type>.source#key:<apikey>`` metric.
 
 Each request may use one or multiple of these sources to deliver a result.
 We log the same metrics as mentioned above for the result.
 
 All of this combined might lead to a tagged metric like:
 
-``locate.source#key:test,region:de,source:geoip,accuracy:low,status:hit``
+``locate.source#key:test,source:geoip,accuracy:low,status:hit``
+
+.. versionchanged:: 2020.04.unreleased
+   Removed the ``region`` tag
 
 .. _locate.fallback.cache:
 .. _locate.fallback.lookup:

--- a/ichnaea/api/locate/query.py
+++ b/ichnaea/api/locate/query.py
@@ -336,13 +336,9 @@ class Query(object):
         possible_result = bool(self.expected_accuracy != DataAccuracy.none)
         return allowed and possible_result
 
-    def _emit_region_stat(self, metric, extra_tags):
-        region = self.region
-        if not region:
-            region = "none"
-
+    def _emit_stat(self, metric, extra_tags):
         metric = "%s.%s" % (self.api_type, metric)
-        tags = ["key:%s" % self.api_key.valid_key, "region:%s" % region]
+        tags = ["key:%s" % self.api_key.valid_key]
         METRICS.incr(metric, tags=tags + extra_tags)
 
     def emit_query_stats(self):
@@ -361,7 +357,7 @@ class Query(object):
         for name, length in (("blue", blues), ("cell", cells), ("wifi", wifis)):
             num = METRIC_MAPPING[min(length, 2)]
             tags.append("{name}:{num}".format(name=name, num=num))
-        self._emit_region_stat("query", tags)
+        self._emit_stat("query", tags)
 
     def emit_result_stats(self, result):
         """Emit stats about how well the result satisfied the query."""
@@ -391,7 +387,7 @@ class Query(object):
         ]
         if status == "hit" and source:
             tags.append("source:%s" % source.name)
-        self._emit_region_stat("result", tags)
+        self._emit_stat("result", tags)
 
     def emit_source_stats(self, source, results):
         """Emit stats about how well the source satisfied the query."""
@@ -411,4 +407,4 @@ class Query(object):
             "accuracy:%s" % self.expected_accuracy.name,
             "status:%s" % status,
         ]
-        self._emit_region_stat("source", tags)
+        self._emit_stat("source", tags)

--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -344,7 +344,7 @@ class CommonLocateTest(BaseLocateTest):
                 "incr",
                 self.metric_type + ".query",
                 value=1,
-                tags=["key:test", "region:GB", "blue:none", "cell:none", "wifi:none"],
+                tags=["key:test", "blue:none", "cell:none", "wifi:none"],
             )
             assert metricsmock.has_record(
                 "incr",
@@ -352,7 +352,6 @@ class CommonLocateTest(BaseLocateTest):
                 value=1,
                 tags=[
                     "key:test",
-                    "region:GB",
                     "fallback_allowed:false",
                     "accuracy:low",
                     "status:hit",
@@ -363,13 +362,7 @@ class CommonLocateTest(BaseLocateTest):
                 "incr",
                 self.metric_type + ".source",
                 value=1,
-                tags=[
-                    "key:test",
-                    "region:GB",
-                    "source:geoip",
-                    "accuracy:low",
-                    "status:hit",
-                ],
+                tags=["key:test", "source:geoip", "accuracy:low", "status:hit"],
             )
 
     def test_error_no_json(self, app, data_queues, metricsmock):
@@ -530,14 +523,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".query",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "geoip:false",
-                "blue:many",
-                "cell:none",
-                "wifi:none",
-            ],
+            tags=["key:test", "geoip:false", "blue:many", "cell:none", "wifi:none"],
         )
         assert metricsmock.has_record(
             "incr",
@@ -545,7 +531,6 @@ class CommonPositionTest(BaseLocateTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "accuracy:high",
                 "fallback_allowed:false",
                 "status:miss",
@@ -555,13 +540,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:high",
-                "status:miss",
-            ],
+            tags=["key:test", "source:internal", "accuracy:high", "status:miss"],
         )
         assert metricsmock.has_record(
             "timing", "request.timing", tags=[self.metric_path, "method:post"]
@@ -589,14 +568,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".query",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "geoip:false",
-                "blue:none",
-                "cell:one",
-                "wifi:none",
-            ],
+            tags=["key:test", "geoip:false", "blue:none", "cell:one", "wifi:none"],
         )
         assert metricsmock.has_record(
             "incr",
@@ -604,7 +576,6 @@ class CommonPositionTest(BaseLocateTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:medium",
                 "status:miss",
@@ -614,13 +585,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:medium",
-                "status:miss",
-            ],
+            tags=["key:test", "source:internal", "accuracy:medium", "status:miss"],
         )
         assert metricsmock.has_record(
             "timing", "request.timing", tags=[self.metric_path, "method:post"]
@@ -675,14 +640,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".query",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "geoip:false",
-                "blue:none",
-                "cell:none",
-                "wifi:none",
-            ],
+            tags=["key:test", "geoip:false", "blue:none", "cell:none", "wifi:none"],
         )
         assert metricsmock.has_record(
             "incr",
@@ -690,7 +648,6 @@ class CommonPositionTest(BaseLocateTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:low",
                 "status:hit",
@@ -701,13 +658,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:low",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:low", "status:hit"],
         )
 
     def test_cellarea_with_lacf(self, app, session, metricsmock):
@@ -735,14 +686,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".query",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "geoip:false",
-                "blue:none",
-                "cell:none",
-                "wifi:none",
-            ],
+            tags=["key:test", "geoip:false", "blue:none", "cell:none", "wifi:none"],
         )
         assert metricsmock.has_record(
             "incr",
@@ -750,7 +694,6 @@ class CommonPositionTest(BaseLocateTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:low",
                 "status:hit",
@@ -761,13 +704,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:low",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:low", "status:hit"],
         )
 
     def test_cellarea_without_lacf(self, app, data_queues, session, metricsmock):
@@ -819,7 +756,6 @@ class CommonPositionTest(BaseLocateTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:low",
                 "status:hit",
@@ -850,14 +786,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".query",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "geoip:false",
-                "blue:none",
-                "cell:none",
-                "wifi:many",
-            ],
+            tags=["key:test", "geoip:false", "blue:none", "cell:none", "wifi:many"],
         )
         assert metricsmock.has_record(
             "incr",
@@ -865,7 +794,6 @@ class CommonPositionTest(BaseLocateTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "accuracy:high",
                 "fallback_allowed:false",
                 "status:miss",
@@ -875,13 +803,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:high",
-                "status:miss",
-            ],
+            tags=["key:test", "source:internal", "accuracy:high", "status:miss"],
         )
         assert metricsmock.has_record(
             "timing", "request.timing", tags=[self.metric_path, "method:post"]
@@ -949,14 +871,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".query",
             value=1,
-            tags=[
-                "key:fall",
-                "region:none",
-                "geoip:false",
-                "blue:none",
-                "cell:many",
-                "wifi:many",
-            ],
+            tags=["key:fall", "geoip:false", "blue:none", "cell:many", "wifi:many"],
         )
         assert metricsmock.has_record(
             "incr",
@@ -964,7 +879,6 @@ class CommonPositionTest(BaseLocateTest):
             value=1,
             tags=[
                 "key:fall",
-                "region:none",
                 "fallback_allowed:true",
                 "accuracy:high",
                 "status:hit",
@@ -975,25 +889,13 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:fall",
-                "region:none",
-                "source:internal",
-                "accuracy:high",
-                "status:miss",
-            ],
+            tags=["key:fall", "source:internal", "accuracy:high", "status:miss"],
         )
         assert metricsmock.has_record(
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:fall",
-                "region:none",
-                "source:fallback",
-                "accuracy:high",
-                "status:hit",
-            ],
+            tags=["key:fall", "source:fallback", "accuracy:high", "status:hit"],
         )
         assert metricsmock.has_record(
             "timing", "request.timing", tags=[self.metric_path, "method:post"]
@@ -1035,7 +937,6 @@ class CommonPositionTest(BaseLocateTest):
             value=1,
             tags=[
                 "key:fall",
-                "region:GB",
                 "fallback_allowed:true",
                 "accuracy:high",
                 "status:hit",
@@ -1046,13 +947,7 @@ class CommonPositionTest(BaseLocateTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:fall",
-                "region:GB",
-                "source:fallback",
-                "accuracy:high",
-                "status:hit",
-            ],
+            tags=["key:fall", "source:fallback", "accuracy:high", "status:hit"],
         )
         assert metricsmock.has_record(
             "timing", "request.timing", tags=[self.metric_path, "method:post"]

--- a/ichnaea/api/locate/tests/test_fallback.py
+++ b/ichnaea/api/locate/tests/test_fallback.py
@@ -1279,13 +1279,7 @@ class TestDefaultFallback(BaseFallbackTest, BaseSourceTest):
                 "incr",
                 "locate.source",
                 value=1,
-                tags=[
-                    "key:test",
-                    "region:none",
-                    "source:fallback",
-                    "accuracy:medium",
-                    "status:hit",
-                ],
+                tags=["key:test", "source:fallback", "accuracy:medium", "status:hit"],
             )
 
     def test_dont_recache(self, geoip_db, http_session, session, source, metricsmock):

--- a/ichnaea/api/locate/tests/test_internal.py
+++ b/ichnaea/api/locate/tests/test_internal.py
@@ -33,13 +33,7 @@ class TestRegionSource(BaseSourceTest):
             "incr",
             self.api_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:low",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:low", "status:hit"],
         )
 
     def test_blue_miss(self, geoip_db, http_session, session, source):
@@ -63,13 +57,7 @@ class TestRegionSource(BaseSourceTest):
             "incr",
             self.api_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:low",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:low", "status:hit"],
         )
 
     def test_ambiguous_mcc(self, geoip_db, http_session, session, source, metricsmock):
@@ -91,13 +79,7 @@ class TestRegionSource(BaseSourceTest):
             "incr",
             self.api_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:low",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:low", "status:hit"],
         )
 
     def test_multiple_mcc(self, geoip_db, http_session, session, source):
@@ -143,13 +125,7 @@ class TestRegionSource(BaseSourceTest):
             "incr",
             self.api_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:low",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:low", "status:hit"],
         )
 
     def test_wifi_miss(self, geoip_db, http_session, session, source):

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -122,7 +122,6 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:high",
                 "status:hit",
@@ -133,13 +132,7 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:high",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:high", "status:hit"],
         )
         items = data_queues["update_incoming"].dequeue()
         assert items == [
@@ -228,7 +221,6 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:medium",
                 "status:hit",
@@ -239,13 +231,7 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:medium",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:medium", "status:hit"],
         )
         assert metricsmock.has_record(
             "timing", "request.timing", tags=[self.metric_path, "method:post"]
@@ -338,7 +324,6 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:high",
                 "status:hit",
@@ -349,13 +334,7 @@ class TestView(LocateV1Base, CommonLocateTest, CommonPositionTest):
             "incr",
             self.metric_type + ".source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:high",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:high", "status:hit"],
         )
         assert metricsmock.has_record(
             "timing", "request.timing", tags=[self.metric_path, "method:post"]
@@ -524,7 +503,6 @@ class TestError(LocateV1Base, BaseLocateTest):
                 value=1,
                 tags=[
                     "key:test",
-                    "region:GB",
                     "fallback_allowed:false",
                     "accuracy:high",
                     "status:miss",

--- a/ichnaea/api/locate/tests/test_query.py
+++ b/ichnaea/api/locate/tests/test_query.py
@@ -359,7 +359,7 @@ class TestQueryStats(QueryTest):
             "incr",
             "locate.query",
             value=1,
-            tags=["key:test", "region:GB", "blue:none", "cell:none", "wifi:none"],
+            tags=["key:test", "blue:none", "cell:none", "wifi:none"],
         )
 
     def test_one(self, geoip_db, metricsmock):
@@ -375,7 +375,7 @@ class TestQueryStats(QueryTest):
                 "incr",
                 "locate.query",
                 1,
-                ["key:test", "region:GB", "blue:one", "cell:one", "wifi:one"],
+                ["key:test", "blue:one", "cell:one", "wifi:one"],
             )
         ]
 
@@ -392,7 +392,7 @@ class TestQueryStats(QueryTest):
                 "incr",
                 "locate.query",
                 1,
-                ["key:test", "region:GB", "blue:many", "cell:many", "wifi:many"],
+                ["key:test", "blue:many", "cell:many", "wifi:many"],
             )
         ]
 
@@ -450,13 +450,7 @@ class TestResultStats(QueryTest):
             "incr",
             "region.result",
             value=1,
-            tags=[
-                "key:test",
-                "region:GB",
-                "fallback_allowed:false",
-                "accuracy:low",
-                "status:hit",
-            ],
+            tags=["key:test", "fallback_allowed:false", "accuracy:low", "status:hit"],
         )
 
     def test_no_ip(self, geoip_db, metricsmock):
@@ -474,13 +468,7 @@ class TestResultStats(QueryTest):
             "incr",
             "locate.result",
             value=1,
-            tags=[
-                "key:test",
-                "region:GB",
-                "fallback_allowed:false",
-                "accuracy:low",
-                "status:miss",
-            ],
+            tags=["key:test", "fallback_allowed:false", "accuracy:low", "status:miss"],
         )
 
     def test_low_miss(self, geoip_db, metricsmock):
@@ -489,13 +477,7 @@ class TestResultStats(QueryTest):
             "incr",
             "locate.result",
             value=1,
-            tags=[
-                "key:test",
-                "region:GB",
-                "fallback_allowed:false",
-                "accuracy:low",
-                "status:miss",
-            ],
+            tags=["key:test", "fallback_allowed:false", "accuracy:low", "status:miss"],
         )
 
     def test_low_hit(self, geoip_db, metricsmock):
@@ -506,13 +488,7 @@ class TestResultStats(QueryTest):
             "incr",
             "locate.result",
             value=1,
-            tags=[
-                "key:test",
-                "region:GB",
-                "fallback_allowed:false",
-                "accuracy:low",
-                "status:hit",
-            ],
+            tags=["key:test", "fallback_allowed:false", "accuracy:low", "status:hit"],
         )
 
     def test_medium_miss(self, geoip_db, metricsmock):
@@ -524,7 +500,6 @@ class TestResultStats(QueryTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:medium",
                 "status:miss",
@@ -540,7 +515,6 @@ class TestResultStats(QueryTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:medium",
                 "status:miss",
@@ -556,7 +530,6 @@ class TestResultStats(QueryTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:medium",
                 "status:hit",
@@ -572,7 +545,6 @@ class TestResultStats(QueryTest):
             value=1,
             tags=[
                 "key:test",
-                "region:none",
                 "fallback_allowed:false",
                 "accuracy:high",
                 "status:miss",
@@ -586,13 +558,7 @@ class TestResultStats(QueryTest):
             "incr",
             "locate.result",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "fallback_allowed:false",
-                "accuracy:high",
-                "status:hit",
-            ],
+            tags=["key:test", "fallback_allowed:false", "accuracy:high", "status:hit"],
         )
 
     def test_mixed_miss(self, geoip_db, metricsmock):
@@ -606,7 +572,6 @@ class TestResultStats(QueryTest):
             value=1,
             tags=[
                 "key:test",
-                "region:GB",
                 "fallback_allowed:false",
                 "accuracy:high",
                 "status:miss",
@@ -624,7 +589,6 @@ class TestResultStats(QueryTest):
             value=1,
             tags=[
                 "key:test",
-                "region:GB",
                 "fallback_allowed:false",
                 "accuracy:medium",
                 "status:hit",
@@ -676,13 +640,7 @@ class TestSourceStats(QueryTest):
             "incr",
             "locate.source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:high",
-                "status:hit",
-            ],
+            tags=["key:test", "source:internal", "accuracy:high", "status:hit"],
         )
 
     def test_high_miss(self, geoip_db, metricsmock):
@@ -693,13 +651,7 @@ class TestSourceStats(QueryTest):
             "incr",
             "locate.source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:geoip",
-                "accuracy:high",
-                "status:miss",
-            ],
+            tags=["key:test", "source:geoip", "accuracy:high", "status:miss"],
         )
 
     def test_no_results(self, geoip_db, metricsmock):
@@ -710,11 +662,5 @@ class TestSourceStats(QueryTest):
             "incr",
             "locate.source",
             value=1,
-            tags=[
-                "key:test",
-                "region:none",
-                "source:internal",
-                "accuracy:high",
-                "status:miss",
-            ],
+            tags=["key:test", "source:internal", "accuracy:high", "status:miss"],
         )


### PR DESCRIPTION
As discussed on [bug 1623470](https://bugzilla.mozilla.org/show_bug.cgi?id=1623470), the `region` tag leads to InfluxDB query inefficiencies due to high cardinality.  Thanks to @sciurus for the bulk of this code. My changes are for linting and the metrics docs.

Our plan is to move the `region` tag to the logs, and analyze regions with BigQuery. 