### PR TITLE
Show tracebacks in local development environment

### DIFF
--- a/ichnaea/webapp/app.py
+++ b/ichnaea/webapp/app.py
@@ -13,6 +13,7 @@ import sys
 
 from waitress import serve
 
+from ichnaea.conf import settings
 from ichnaea.webapp.config import main, shutdown_worker
 
 
@@ -77,5 +78,8 @@ if __name__ == "__main__":
         main(ping_connections=False)
     else:
         serve(
-            log_access_factory(main(ping_connections=True)), host="0.0.0.0", port=8000
+            log_access_factory(main(ping_connections=True)),
+            host="0.0.0.0",
+            port=8000,
+            expose_tracebacks=settings("local_dev_env"),
         )


### PR DESCRIPTION
`expose_tracebacks` will show the traceback when a request raises an exception. Otherwise, a generic "an exception occured" message is returned.

I believe this file is run as ``__main__`` only in development (we use nginx and gunicorn in production, and probably refer directly to `ichnaea.webapp.app.wsgi_app`), but I based it off the `local_dev_env` setting just in case.