### PR TITLE
bug 1632621: Use log_middleware in gunicorn

### DIFF
--- a/ichnaea/webapp/app.py
+++ b/ichnaea/webapp/app.py
@@ -38,7 +38,7 @@ def wsgi_app(environ, start_response):
     global _APP
 
     if _APP is None:
-        _APP = main(ping_connections=True)
+        _APP = log_middleware(main(ping_connections=True))
         if environ is None and start_response is None:
             # Called as part of gunicorn's post_worker_init
             return _APP


### PR DESCRIPTION
When running under gunicorn, use ``log_middleware`` to produce the ``canonical-log-line`` structured logs.

To test locally, I add this to ``my.env``:

```
LOCAL_DEV_ENV=False
```

and then ran ``make run``. Output with a call to ``/v1/country?key=test``:

```
web_1        | {"Timestamp": 1588627191391223296, "Type": "canonical-log-line", "Logger": "ichnaea", "Hostname": "177132d32fa9", "EnvVersion": "2.0", "Severity": 6, "Pid": 19, "Fields": {"http_method": "GET", "http_path": "/v1/country", "api_path": "v1.country", "api_key": "test", "api_type": "region", "region": null, "blue": 0, "blue_valid": 0, "cell": 0, "cell_valid": 0, "wifi": 0, "wifi_valid": 0, "has_geoip": false, "has_ip": true, "source_geoip_accuracy": null, "source_geoip_accuracy_min": "low", "source_geoip_status": "miss", "fallback_allowed": false, "accuracy": "none", "accuracy_min": "low", "result_status": "miss", "http_status": 404, "duration": 0.009, "content_length": 122, "msg": "GET /v1/country - 404 Not Found (122)"}}
```