### PR TITLE
bug 1632621: Move structured logging to log_tween_factory

### DIFF
--- a/ichnaea/conftest.py
+++ b/ichnaea/conftest.py
@@ -5,7 +5,6 @@ import gc
 import warnings
 
 from alembic.config import main as alembic_main
-from markus.testing import MetricsMock
 from maxminddb.const import MODE_AUTO
 import pytest
 from sqlalchemy import event, inspect, text
@@ -28,6 +27,11 @@ from ichnaea.queue import DataQueue
 from ichnaea.taskapp.app import celery_app
 from ichnaea.taskapp.config import init_worker, shutdown_worker as shutdown_celery
 from ichnaea.webapp.config import main, shutdown_worker as shutdown_app
+
+# Enable pytest assertion rewriting
+pytest.register_assert_rewrite("markus.testing")
+from markus.testing import MetricsMock  # noqa: E402
+
 
 # Module global to hold active session, used by factory-boy
 SESSION = {}

--- a/ichnaea/content/tests/test_views.py
+++ b/ichnaea/content/tests/test_views.py
@@ -90,7 +90,7 @@ class TestFunctionalContent(object):
     @pytest.mark.parametrize(
         "path,status,metric_path,db_calls",
         (
-            ("/", 200, "", 0),
+            ("/", 200, ".homepage", 0),
             ("/apple-touch-icon-precomposed.png", 200, None, 0),
             ("/api", 200, "api", 0),
             ("/contact", 200, "contact", 0),

--- a/ichnaea/content/tests/test_views.py
+++ b/ichnaea/content/tests/test_views.py
@@ -87,36 +87,40 @@ class TestContentViews(object):
 
 
 class TestFunctionalContent(object):
-    def test_content(self, app, session_tracker, metricsmock):
-        app.get("/", status=200)
-        app.get("/apple-touch-icon-precomposed.png", status=200)
-        app.get("/api", status=200)
-        app.get("/contact", status=200)
-        app.get("/favicon.ico", status=200)
-        app.get("/map", status=200)
-        app.get("/nobody-is-home", status=404)
-        app.get("/optout", status=200)
-        app.get("/privacy", status=200)
-        app.get("/robots.txt", status=200)
-        app.get("/static/css/images/icons-000000@2x.png", status=200)
-        app.get("/terms", status=200)
-        session_tracker(0)
-        app.get("/stats/regions", status=200)
-        session_tracker(1)
-        app.get("/stats", status=200)
-        session_tracker(8)
-        assert metricsmock.has_record(
-            "incr", "request", value=1, tags=["path:", "method:get", "status:200"]
-        )
-        assert metricsmock.has_record(
-            "incr", "request", value=1, tags=["path:map", "method:get", "status:200"]
-        )
-        assert metricsmock.has_record(
-            "timing", "request.timing", tags=["path:", "method:get"]
-        )
-        assert metricsmock.has_record(
-            "timing", "request.timing", tags=["path:map", "method:get"]
-        )
+    @pytest.mark.parametrize(
+        "path,status,metric_path,db_calls",
+        (
+            ("/", 200, "", 0),
+            ("/apple-touch-icon-precomposed.png", 200, None, 0),
+            ("/api", 200, "api", 0),
+            ("/contact", 200, "contact", 0),
+            ("/favicon.ico", 200, None, 0),
+            ("/map", 200, "map", 0),
+            ("/nobody-is-home", 404, None, 0),
+            ("/optout", 200, "optout", 0),
+            ("/privacy", 200, "privacy", 0),
+            ("/robots.txt", 200, None, 0),
+            ("/static/css/images/icons-000000@2x.png", 200, None, 0),
+            ("/terms", 200, "terms", 0),
+            ("/stats/regions", 200, "stats.regions", 1),
+            ("/stats", 200, "stats", 7),
+        ),
+    )
+    def test_content(
+        self, path, status, metric_path, db_calls, app, session_tracker, metricsmock
+    ):
+        app.get(path, status=status)  # Fails if status doesn't match (WebTest.get)
+        session_tracker(db_calls)  # Fails if number of database calls doesn't match
+        if metric_path is None:
+            # Assert no request metrics emitted
+            metricsmock.assert_not_incr("request.timing")
+            metricsmock.assert_not_incr("request")
+        else:
+            # Assert specific request metrics emitted
+            tags = [f"path:{metric_path}", "method:get"]
+            metricsmock.assert_timing_once("request.timing", tags=tags)
+            tags.append(f"status:{status}")
+            metricsmock.assert_incr_once("request", tags=tags)
 
     @config_override(ASSET_BUCKET="bucket", ASSET_URL="http://127.0.0.1:9/foo")
     def test_downloads(self, app):

--- a/ichnaea/log.py
+++ b/ichnaea/log.py
@@ -207,7 +207,7 @@ def log_tween_factory(handler, registry):
 
             if not is_static_content:
                 # Emit a request.timing and a request metric
-                duration_ms = int(round(duration * 1000))
+                duration_ms = round(duration * 1000)
                 # Convert a URI to to a statsd acceptable metric
                 stats_path = (
                     request.path.replace("/", ".").lstrip(".").replace("@", "-")

--- a/ichnaea/log.py
+++ b/ichnaea/log.py
@@ -250,10 +250,9 @@ def log_tween_factory(handler, registry):
             raise
         except HTTPException as exc:
             # HTTPException: Remaining 5xx (or maybe 2xx) errors from Pyramid
-            # Log, and maybe send to Sentry
+            # Log and send to Sentry
             record_response(exc.status_code)
-            if not is_static_content:
-                registry.raven_client.captureException()
+            registry.raven_client.captureException()
             raise
         except Exception:
             # Any other exception, treat as 500 Internal Server Error

--- a/ichnaea/webapp/app.py
+++ b/ichnaea/webapp/app.py
@@ -9,9 +9,7 @@ making it easier to suss out startup and configuration issues.
 """
 
 import sys
-import time
 
-import structlog
 from waitress import serve
 
 from ichnaea.conf import settings
@@ -38,7 +36,7 @@ def wsgi_app(environ, start_response):
     global _APP
 
     if _APP is None:
-        _APP = log_middleware(main(ping_connections=True))
+        _APP = main(ping_connections=True)
         if environ is None and start_response is None:
             # Called as part of gunicorn's post_worker_init
             return _APP
@@ -50,53 +48,12 @@ def worker_exit(server, worker):
     shutdown_worker(_APP)
 
 
-def log_middleware(wsgi_app):
-    """WSGI middleware for logging."""
-
-    def handle(environ, start_response):
-        method = environ["REQUEST_METHOD"]
-        path = environ.get("PATH_INFO", "")
-        start = time.time()
-        structlog.threadlocal.clear_threadlocal()
-        structlog.threadlocal.bind_threadlocal(http_method=method, http_path=path)
-
-        def log_response(status, headers, exc_info=None):
-            duration = time.time() - start
-            try:
-                status_code = int(status.split()[0])
-            except (ValueError, AttributeError, IndexError):
-                status_code = status
-
-            params = {
-                "http_status": status_code,
-                "duration": round(duration, 3),  # Round to milliseconds
-            }
-
-            content_length_str = ""
-            for key, val in headers:
-                if key.lower() == "content-length":
-                    try:
-                        params["content_length"] = int(val)
-                    except ValueError:
-                        pass
-                    content_length_str = f" ({val})"
-                    break
-
-            logger = structlog.get_logger("canonical-log-line")
-            logger.info(f"{method} {path} - {status}{content_length_str}", **params)
-            return start_response(status, headers, exc_info)
-
-        return wsgi_app(environ, log_response)
-
-    return handle
-
-
 if __name__ == "__main__":
     if "--check" in sys.argv:
         main(ping_connections=False)
     else:
         serve(
-            log_middleware(main(ping_connections=True)),
+            main(ping_connections=True),
             host="0.0.0.0",
             port=8000,
             expose_tracebacks=settings("local_dev_env"),


### PR DESCRIPTION
PR #1163 added ``log_middleware`` to ``wsgi_app``, so that structured logging was available in deployments with gunicorn as well as development. This takes it a step further and moves logging to ``log_tween_factory``, a "tween" (Pyramid middleware) that already handles request-level metrics and raven exception capturing.

The ``log_tween`` method has quite a few changes:

* The shortcut handler for static assets (served from `/static` or has a `skip_logging` attribute like `/robots.txt`) has been removed and integrated into the rest of the logic. This means some stuff like clearing the structured log and capturing the current time happens for these requests as well, but I was already doing this in ``log_middleware``. I _think_ I got the exception handling logic merged correctly, but if more exceptions than expected show up, we can adjust.
* I combined `timer_send` and `counter_send` into `record_response`, which sends the `request.timing` and `request` metrics (except for static assets) and emits the `canonical-log-line` (except for static assets in deployments)
* I split up the generic ``Exception`` handler into an ``HTTPException`` and ``Exception`` handlers
* Lots of docstrings and comments.

There are some changes to the `canonical-log-line`:
* `duration` is now `duration_s`, to add the units (seconds) to the name. It is now identical to the `request.timing` metric, which is in milliseconds.
* I dropped ``content_length``, since that would require reading the response body iterator, and it seems low value to me. I also dropped it from the human-readable method.
* The log will no longer be emitted for static assets

I made a set of similar requests, with dev tools open and the cache disabled:

* http://localhost:8000/static/css/bundle-base.css
* http://localhost:8000/v1/country
* http://localhost:8000/v1/country?key=bad_key (invalid key)
* http://localhost:8000/v1/country?key=test  (valid key, but still local IP so no country)

With standard development environment settings, the output is:

```
web_1        | Starting Web Server
web_1        | 2020-05-06T21:47:33.443431Z [debug    ] Configuring Raven for host: None [ichnaea.log.DebugRavenClient] 
web_1        | 2020-05-06T21:47:33.474033Z [info     ] GeoIP configured.              [ichnaea.geoip] 
web_1        | *****************************************************************************
web_1        | Running webapp in local dev environment.
web_1        | Connect at http://localhost:8000
web_1        | *****************************************************************************
web_1        | 2020-05-06T21:47:36.142055Z [debug    ] Configuring Raven for host: None [ichnaea.log.DebugRavenClient] 
web_1        | 2020-05-06T21:47:36.164577Z [info     ] GeoIP configured.              [ichnaea.geoip] 
web_1        | Serving on http://0.0.0.0:8000
web_1        | 2020-05-06T21:48:06.354243Z [info     ] METRICS|2020-05-06 21:48:06|timing|request.timing|164|#path:,method:get [markus] 
web_1        | 2020-05-06T21:48:06.354521Z [info     ] METRICS|2020-05-06 21:48:06|incr|request|1|#path:,method:get,status:200 [markus] 
web_1        | 2020-05-06T21:48:06.354888Z [info     ] GET / - 200                    [canonical-log-line] duration_s=0.164 http_method=GET http_path=/ http_status=200
web_1        | 2020-05-06T21:48:06.487824Z [info     ] GET /static/css/bundle-base.css - 200 [canonical-log-line] duration_s=0.013 http_method=GET http_path=/static/css/bundle-base.css http_status=200
web_1        | 2020-05-06T21:48:06.488654Z [info     ] GET /static/js/bundle-base.js - 200 [canonical-log-line] duration_s=0.01 http_method=GET http_path=/static/js/bundle-base.js http_status=200
web_1        | 2020-05-06T21:48:06.684327Z [info     ] GET /static/fonts/ZillaSlab-Regular.woff2 - 200 [canonical-log-line] duration_s=0.025 http_method=GET http_path=/static/fonts/ZillaSlab-Regular.woff2 http_status=200
web_1        | 2020-05-06T21:48:06.685862Z [info     ] GET /static/images/mls-logo@2x.png - 200 [canonical-log-line] duration_s=0.023 http_method=GET http_path=/static/images/mls-logo@2x.png http_status=200
web_1        | 2020-05-06T21:48:06.691084Z [info     ] GET /static/fonts/opensans-bold.woff2 - 200 [canonical-log-line] duration_s=0.029 http_method=GET http_path=/static/fonts/opensans-bold.woff2 http_status=200
web_1        | 2020-05-06T21:48:06.693260Z [info     ] GET /static/fonts/ZillaSlabHighlight-Bold.woff2 - 200 [canonical-log-line] duration_s=0.025 http_method=GET http_path=/static/fonts/ZillaSlabHighlight-Bold.woff2 http_status=200
web_1        | 2020-05-06T21:48:06.709501Z [info     ] GET /static/fonts/ZillaSlab-Bold.woff2 - 200 [canonical-log-line] duration_s=0.021 http_method=GET http_path=/static/fonts/ZillaSlab-Bold.woff2 http_status=200
web_1        | 2020-05-06T21:48:06.727007Z [info     ] GET /static/images/moz-logo.svg - 200 [canonical-log-line] duration_s=0.013 http_method=GET http_path=/static/images/moz-logo.svg http_status=200
web_1        | 2020-05-06T21:48:06.958001Z [info     ] GET /static/images/apple-touch-icon.png - 200 [canonical-log-line] duration_s=0.011 http_method=GET http_path=/static/images/apple-touch-icon.png http_status=200
web_1        | 2020-05-06T21:48:06.959653Z [info     ] GET /static/images/favicon.png - 200 [canonical-log-line] duration_s=0.012 http_method=GET http_path=/static/images/favicon.png http_status=200
web_1        | 2020-05-06T21:48:28.753942Z [info     ] METRICS|2020-05-06 21:48:28|incr|region.request|1|#path:v1.country,key:none [markus] 
web_1        | 2020-05-06T21:48:28.754484Z [info     ] METRICS|2020-05-06 21:48:28|timing|request.timing|2|#path:v1.country,method:get [markus] 
web_1        | 2020-05-06T21:48:28.754912Z [info     ] METRICS|2020-05-06 21:48:28|incr|request|1|#path:v1.country,method:get,status:400 [markus] 
web_1        | 2020-05-06T21:48:28.755234Z [info     ] GET /v1/country - 400          [canonical-log-line] api_key=none api_path=v1.country duration_s=0.002 http_method=GET http_path=/v1/country http_status=400
web_1        | 2020-05-06T21:48:46.103012Z [info     ] METRICS|2020-05-06 21:48:46|incr|region.request|1|#path:v1.country,key:none [markus] 
web_1        | 2020-05-06T21:48:46.103755Z [info     ] METRICS|2020-05-06 21:48:46|timing|request.timing|2|#path:v1.country,method:get [markus] 
web_1        | 2020-05-06T21:48:46.104414Z [info     ] METRICS|2020-05-06 21:48:46|incr|request|1|#path:v1.country,method:get,status:400 [markus] 
web_1        | 2020-05-06T21:48:46.104897Z [info     ] GET /v1/country - 400          [canonical-log-line] api_key=none api_path=v1.country duration_s=0.002 http_method=GET http_path=/v1/country http_status=400
web_1        | 2020-05-06T21:48:54.886840Z [info     ] METRICS|2020-05-06 21:48:54|incr|region.request|1|#path:v1.country,key:test [markus] 
web_1        | 2020-05-06T21:48:54.888497Z [info     ] METRICS|2020-05-06 21:48:54|incr|region.query|1|#key:test,blue:none,cell:none,wifi:none [markus] 
web_1        | 2020-05-06T21:48:54.888965Z [info     ] METRICS|2020-05-06 21:48:54|incr|region.source|1|#key:test,source:geoip,accuracy:low,status:miss [markus] 
web_1        | 2020-05-06T21:48:54.889293Z [info     ] METRICS|2020-05-06 21:48:54|incr|region.result|1|#key:test,fallback_allowed:false,accuracy:low,status:miss [markus] 
web_1        | 2020-05-06T21:48:54.891211Z [info     ] METRICS|2020-05-06 21:48:54|timing|request.timing|15|#path:v1.country,method:get [markus] 
web_1        | 2020-05-06T21:48:54.891417Z [info     ] METRICS|2020-05-06 21:48:54|incr|request|1|#path:v1.country,method:get,status:404 [markus] 
web_1        | 2020-05-06T21:48:54.891598Z [info     ] GET /v1/country - 404          [canonical-log-line] accuracy=none accuracy_min=low api_key=test api_path=v1.country api_type=region blue=0 blue_valid=0 cell=0 cell_valid=0 duration_s=0.015 fallback_allowed=False has_geoip=False has_ip=True http_method=GET http_path=/v1/country http_status=404 region=None result_status=miss source_geoip_accuracy=None source_geoip_accuracy_min=low source_geoip_status=miss wifi=0 wifi_valid=0
```

With ``LOCAL_DEV_ENV=False``, the server acts more like production, not logging static assets or showing the debug metrics logs:

```
web_1        | Starting Web Server
web_1        | {"Timestamp": 1588801913669888256, "Type": "ichnaea.log.DebugRavenClient", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 7, "Pid": 8, "Fields": {"msg": "Configuring Raven for host: None"}}
web_1        | {"Timestamp": 1588801913674902528, "Type": "ichnaea.log", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 4, "Pid": 8, "Fields": {"msg": "STATSD_HOST not set; no statsd configured"}}
web_1        | {"Timestamp": 1588801913678728960, "Type": "ichnaea.geoip", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 6, "Pid": 8, "Fields": {"msg": "GeoIP configured."}}
web_1        | + gunicorn --pythonpath /app --workers=1 --worker-class=ichnaea.webapp.worker.LocationGeventWorker --worker-connections=4 --max-requests=10000 --max-requests-jitter=1000 --capture-output --error-logfile=- --access-logfile=- --log-file=- --timeout=60 --config=python:ichnaea.webapp.gunicorn_settings --bind 0.0.0.0:8000 ichnaea.webapp.app:wsgi_app
web_1        | [2020-05-06 21:51:54 +0000] [17] [INFO] Starting gunicorn 20.0.4
web_1        | [2020-05-06 21:51:54 +0000] [17] [INFO] Listening at: http://0.0.0.0:8000 (17)
web_1        | [2020-05-06 21:51:54 +0000] [17] [INFO] Using worker: ichnaea.webapp.worker.LocationGeventWorker
web_1        | [2020-05-06 21:51:54 +0000] [19] [INFO] Booting worker with pid: 19
web_1        | {"Timestamp": 1588801916366337536, "Type": "ichnaea.log.DebugRavenClient", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 7, "Pid": 19, "Fields": {"msg": "Configuring Raven for host: None"}}
web_1        | {"Timestamp": 1588801916371073536, "Type": "ichnaea.log", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 4, "Pid": 19, "Fields": {"msg": "STATSD_HOST not set; no statsd configured"}}
web_1        | {"Timestamp": 1588801916375422976, "Type": "ichnaea.geoip", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 6, "Pid": 19, "Fields": {"msg": "GeoIP configured."}}
web_1        | {"Timestamp": 1588801940966204416, "Type": "canonical-log-line", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 6, "Pid": 19, "Fields": {"http_method": "GET", "http_path": "/", "http_status": 200, "duration_s": 0.155, "msg": "GET / - 200"}}
web_1        | {"Timestamp": 1588801961840768512, "Type": "canonical-log-line", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 6, "Pid": 19, "Fields": {"http_method": "GET", "http_path": "/v1/country", "api_path": "v1.country", "api_key": "none", "http_status": 400, "duration_s": 0.002, "msg": "GET /v1/country - 400"}}
web_1        | {"Timestamp": 1588801965173412864, "Type": "canonical-log-line", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 6, "Pid": 19, "Fields": {"http_method": "GET", "http_path": "/v1/country", "api_path": "v1.country", "api_key": "none", "http_status": 400, "duration_s": 0.0, "msg": "GET /v1/country - 400"}}
web_1        | {"Timestamp": 1588801966964704512, "Type": "canonical-log-line", "Logger": "ichnaea", "Hostname": "f8056f45dcfb", "EnvVersion": "2.0", "Severity": 6, "Pid": 19, "Fields": {"http_method": "GET", "http_path": "/v1/country", "api_path": "v1.country", "api_key": "test", "api_type": "region", "region": null, "blue": 0, "blue_valid": 0, "cell": 0, "cell_valid": 0, "wifi": 0, "wifi_valid": 0, "has_geoip": false, "has_ip": true, "source_geoip_accuracy": null, "source_geoip_accuracy_min": "low", "source_geoip_status": "miss", "fallback_allowed": false, "accuracy": "none", "accuracy_min": "low", "result_status": "miss", "http_status": 404, "duration_s": 0.009, "msg": "GET /v1/country - 404"}}
```