### PR TITLE
bug 1632621: Test structured logging, expand API logging

### DIFF
--- a/ichnaea/api/locate/query.py
+++ b/ichnaea/api/locate/query.py
@@ -93,7 +93,6 @@ class Query(object):
         self.api_type = api_type
 
         bind_threadlocal(
-            api_type=api_type,
             region=self.region,
             blue=len(blue or []),
             blue_valid=len(self.blue),

--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -278,6 +278,8 @@ class BaseLocateTest(object):
 class CommonLocateTest(BaseLocateTest):
     """Common tests for geolocate and region APIs."""
 
+    ip_log_and_rate_limit = True
+
     def test_get(self, app, data_queues, metricsmock, logs):
         """A GET returns an IP-based location."""
         res = self._call(app, ip=self.test_ip, method="get", status=200)
@@ -320,6 +322,8 @@ class CommonLocateTest(BaseLocateTest):
             "wifi": 0,
             "wifi_valid": 0,
         }
+        if self.ip_log_and_rate_limit:
+            expected_entry["api_key_count"] = expected_entry["api_key_ip_count"] = 1
         assert logs.entry == expected_entry
 
     def test_options(self, app, logs):

--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -323,7 +323,8 @@ class CommonLocateTest(BaseLocateTest):
             "wifi_valid": 0,
         }
         if self.ip_log_and_rate_limit:
-            expected_entry["api_key_count"] = expected_entry["api_key_ip_count"] = 1
+            expected_entry["api_key_count"] = 1
+            expected_entry["api_key_repeat_ip"] = False
         assert logs.entry == expected_entry
 
     def test_options(self, app, logs):

--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -454,7 +454,7 @@ class CommonLocateTest(BaseLocateTest):
         headers = {"Content-Encoding": "gzip"}
         res = self._call(app, body=body, headers=headers, method="post", status=404)
         self.check_response(data_queues, res, "not_found")
-        assert logs.entry["wifi"] == logs.entry["wifi_valid"] == 2
+        assert logs.entry["wifi_valid"] == 2
 
     def test_truncated_gzip(self, app, data_queues):
         """An incomplete gzip-encoded body is an error."""

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -114,7 +114,7 @@ class TestView(LocateV1Base, CommonLocateTest):
             "api_key_repeat_ip": False,
             "api_path": self.metric_path.split(":")[1],
             "api_type": self.metric_type,
-            "duration_s": logs.entry["duration_s"],
+            "duration_s": logs.only_entry["duration_s"],
             "event": f"POST {self.url} - 403",
             "http_method": "POST",
             "http_path": self.url,
@@ -124,7 +124,7 @@ class TestView(LocateV1Base, CommonLocateTest):
             "rate_quota": 5,
             "rate_remaining": 0,
         }
-        assert logs.entry == expected_entry
+        assert logs.only_entry == expected_entry
 
     def test_api_key_blocked(self, app, data_queues, session, logs):
         """A 400 is returned when a key is blocked from locate APIs."""
@@ -134,7 +134,7 @@ class TestView(LocateV1Base, CommonLocateTest):
         res = self._call(app, api_key=api_key.valid_key, ip=self.test_ip, status=400)
         self.check_response(data_queues, res, "invalid_key")
 
-        log = logs.entry
+        log = logs.only_entry
         assert log["api_key"] == api_key.valid_key
         assert not log["api_key_allowed"]
 
@@ -164,7 +164,7 @@ class TestView(LocateV1Base, CommonLocateTest):
             self.metric_type + ".source",
             tags=["key:test", "source:internal", "accuracy:high", "status:miss"],
         )
-        assert logs.entry["blue_valid"] == 2
+        assert logs.only_entry["blue_valid"] == 2
 
     def test_cell_not_found(self, app, data_queues, metricsmock, logs):
         """A failed cell-based lookup emits several metrics."""
@@ -196,7 +196,7 @@ class TestView(LocateV1Base, CommonLocateTest):
             self.metric_type + ".source",
             tags=["key:test", "source:internal", "accuracy:medium", "status:miss"],
         )
-        assert logs.entry["cell_valid"] == 1
+        assert logs.only_entry["cell_valid"] == 1
 
     def test_cell_invalid_lac(self, app, data_queues, logs):
         """A valid CID with and invalid LAC is not an error."""
@@ -205,8 +205,8 @@ class TestView(LocateV1Base, CommonLocateTest):
         res = self._call(app, body=query, status=404)
         self.check_response(data_queues, res, "not_found")
 
-        assert logs.entry["cell"] == 1
-        assert logs.entry["cell_valid"] == 0
+        assert logs.only_entry["cell"] == 1
+        assert logs.only_entry["cell_valid"] == 0
 
     def test_cell_lte_radio(self, app, session, metricsmock, logs):
         """A known LTE station can be used for lookups."""
@@ -222,7 +222,7 @@ class TestView(LocateV1Base, CommonLocateTest):
         metricsmock.assert_incr_once(
             "request", tags=[self.metric_path, "method:post", "status:200"]
         )
-        assert logs.entry["cell_valid"] == 1
+        assert logs.only_entry["cell_valid"] == 1
 
     @pytest.mark.parametrize("fallback", ("explicit", "default", "ipf"))
     def test_cellarea(self, app, session, metricsmock, fallback, logs):
@@ -267,8 +267,8 @@ class TestView(LocateV1Base, CommonLocateTest):
             self.metric_type + ".source",
             tags=["key:test", "source:internal", "accuracy:low", "status:hit"],
         )
-        assert logs.entry["cell"] == 1
-        assert logs.entry["cell_valid"] == 0
+        assert logs.only_entry["cell"] == 1
+        assert logs.only_entry["cell_valid"] == 0
 
     def test_cellarea_without_lacf(self, app, data_queues, session, metricsmock, logs):
         """The cell location area fallback can be disabled."""
@@ -287,8 +287,8 @@ class TestView(LocateV1Base, CommonLocateTest):
             self.metric_type + ".request", tags=[self.metric_path, "key:test"]
         )
 
-        assert logs.entry["cell"] == 1
-        assert logs.entry["cell_valid"] == 0
+        assert logs.only_entry["cell"] == 1
+        assert logs.only_entry["cell_valid"] == 0
 
     def test_wifi_not_found(self, app, data_queues, metricsmock, logs):
         """A failed WiFi-based lookup emits several metrics."""
@@ -316,7 +316,7 @@ class TestView(LocateV1Base, CommonLocateTest):
             self.metric_type + ".source",
             tags=["key:test", "source:internal", "accuracy:high", "status:miss"],
         )
-        assert logs.entry["wifi_valid"] == 2
+        assert logs.only_entry["wifi_valid"] == 2
 
     def test_ip_fallback_disabled(self, app, data_queues, metricsmock, logs):
         """The IP-based location fallback can be disabled."""
@@ -330,8 +330,8 @@ class TestView(LocateV1Base, CommonLocateTest):
         metricsmock.assert_incr_once(
             self.metric_type + ".request", tags=[self.metric_path, "key:test"]
         )
-        assert logs.entry["has_geoip"]
-        assert "source_geoip_status" not in logs.entry
+        assert logs.only_entry["has_geoip"]
+        assert "source_geoip_status" not in logs.only_entry
 
     @pytest.mark.parametrize("with_ip", [True, False])
     def test_fallback(self, app, session, metricsmock, with_ip, logs):
@@ -399,7 +399,7 @@ class TestView(LocateV1Base, CommonLocateTest):
             tags=["key:fall", "source:fallback", "accuracy:high", "status:hit"],
         )
 
-        log = logs.entry
+        log = logs.only_entry
         assert log["cell_valid"] == 2
         assert log["wifi_valid"] == 3
         assert log["fallback_allowed"]
@@ -759,7 +759,7 @@ class TestError(LocateV1Base, BaseLocateTest):
             "blue_valid": 0,
             "cell": 2,
             "cell_valid": 2,
-            "duration_s": logs.entry["duration_s"],
+            "duration_s": logs.only_entry["duration_s"],
             "event": "POST /v1/geolocate - 200",
             "has_geoip": True,
             "has_ip": True,
@@ -771,7 +771,7 @@ class TestError(LocateV1Base, BaseLocateTest):
             "wifi": 2,
             "wifi_valid": 2,
         }
-        assert logs.entry == expected_entry
+        assert logs.only_entry == expected_entry
 
     def test_database_error(
         self, app, data_queues, raven, session, metricsmock, restore_db, logs
@@ -821,7 +821,7 @@ class TestError(LocateV1Base, BaseLocateTest):
             "blue_valid": 0,
             "cell": 3,
             "cell_valid": 3,
-            "duration_s": logs.entry["duration_s"],
+            "duration_s": logs.only_entry["duration_s"],
             "event": "POST /v1/geolocate - 200",
             "fallback_allowed": False,
             "has_geoip": True,
@@ -841,5 +841,4 @@ class TestError(LocateV1Base, BaseLocateTest):
             "wifi": 2,
             "wifi_valid": 2,
         }
-
-        assert logs.entry == expected_entry
+        assert logs.only_entry == expected_entry

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -111,7 +111,7 @@ class TestView(LocateV1Base, CommonLocateTest):
         expected_entry = {
             "api_key": api_key.valid_key,
             "api_key_count": 11,
-            "api_key_ip_count": 1,
+            "api_key_repeat_ip": False,
             "api_path": self.metric_path.split(":")[1],
             "api_type": self.metric_type,
             "duration_s": logs.entry["duration_s"],
@@ -814,7 +814,7 @@ class TestError(LocateV1Base, BaseLocateTest):
             "accuracy_min": "high",
             "api_key": "test",
             "api_key_count": 1,
-            "api_key_ip_count": 1,
+            "api_key_repeat_ip": False,
             "api_path": "v1.geolocate",
             "api_type": "locate",
             "blue": 0,

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -164,7 +164,7 @@ class TestView(LocateV1Base, CommonLocateTest):
             self.metric_type + ".source",
             tags=["key:test", "source:internal", "accuracy:high", "status:miss"],
         )
-        assert logs.entry["blue"] == logs.entry["blue_valid"] == 2
+        assert logs.entry["blue_valid"] == 2
 
     def test_cell_not_found(self, app, data_queues, metricsmock, logs):
         """A failed cell-based lookup emits several metrics."""
@@ -196,7 +196,7 @@ class TestView(LocateV1Base, CommonLocateTest):
             self.metric_type + ".source",
             tags=["key:test", "source:internal", "accuracy:medium", "status:miss"],
         )
-        assert logs.entry["cell"] == logs.entry["cell_valid"] == 1
+        assert logs.entry["cell_valid"] == 1
 
     def test_cell_invalid_lac(self, app, data_queues, logs):
         """A valid CID with and invalid LAC is not an error."""
@@ -222,7 +222,7 @@ class TestView(LocateV1Base, CommonLocateTest):
         metricsmock.assert_incr_once(
             "request", tags=[self.metric_path, "method:post", "status:200"]
         )
-        assert logs.entry["cell"] == logs.entry["cell_valid"] == 1
+        assert logs.entry["cell_valid"] == 1
 
     @pytest.mark.parametrize("fallback", ("explicit", "default", "ipf"))
     def test_cellarea(self, app, session, metricsmock, fallback, logs):
@@ -316,7 +316,7 @@ class TestView(LocateV1Base, CommonLocateTest):
             self.metric_type + ".source",
             tags=["key:test", "source:internal", "accuracy:high", "status:miss"],
         )
-        assert logs.entry["wifi"] == logs.entry["wifi_valid"] == 2
+        assert logs.entry["wifi_valid"] == 2
 
     def test_ip_fallback_disabled(self, app, data_queues, metricsmock, logs):
         """The IP-based location fallback can be disabled."""
@@ -400,8 +400,8 @@ class TestView(LocateV1Base, CommonLocateTest):
         )
 
         log = logs.entry
-        assert log["cell"] == log["cell_valid"] == 2
-        assert log["wifi"] == log["wifi_valid"] == 3
+        assert log["cell_valid"] == 2
+        assert log["wifi_valid"] == 3
         assert log["fallback_allowed"]
         assert log["source_fallback_accuracy"] == "high"
         assert log["source_fallback_accuracy_min"] == "high"

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -111,6 +111,7 @@ class TestView(LocateV1Base, CommonLocateTest):
         expected_entry = {
             "api_key": api_key.valid_key,
             "api_path": self.metric_path.split(":")[1],
+            "api_type": self.metric_type,
             "duration_s": logs.entry["duration_s"],
             "event": f"POST {self.url} - 403",
             "http_method": "POST",
@@ -745,7 +746,6 @@ class TestError(LocateV1Base, BaseLocateTest):
         raven.check([("ProgrammingError", 1)])
         self.check_queue(data_queues, 0)
         expected_entry = {
-            "api_type": "locate",
             "blue": 0,
             "blue_valid": 0,
             "cell": 2,

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -110,6 +110,8 @@ class TestView(LocateV1Base, CommonLocateTest):
 
         expected_entry = {
             "api_key": api_key.valid_key,
+            "api_key_count": 11,
+            "api_key_ip_count": 1,
             "api_path": self.metric_path.split(":")[1],
             "api_type": self.metric_type,
             "duration_s": logs.entry["duration_s"],
@@ -118,6 +120,9 @@ class TestView(LocateV1Base, CommonLocateTest):
             "http_path": self.url,
             "http_status": 403,
             "log_level": "info",
+            "rate_allowed": False,
+            "rate_quota": 5,
+            "rate_remaining": 0,
         }
         assert logs.entry == expected_entry
 
@@ -808,6 +813,8 @@ class TestError(LocateV1Base, BaseLocateTest):
             "accuracy": "medium",
             "accuracy_min": "high",
             "api_key": "test",
+            "api_key_count": 1,
+            "api_key_ip_count": 1,
             "api_path": "v1.geolocate",
             "api_type": "locate",
             "blue": 0,

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -746,6 +746,10 @@ class TestError(LocateV1Base, BaseLocateTest):
         raven.check([("ProgrammingError", 1)])
         self.check_queue(data_queues, 0)
         expected_entry = {
+            "api_key": "test",
+            "api_key_db_fail": True,
+            "api_path": "v1.geolocate",
+            "api_type": "locate",
             "blue": 0,
             "blue_valid": 0,
             "cell": 2,

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -130,8 +130,8 @@ class TestView(LocateV1Base, CommonLocateTest):
         self.check_response(data_queues, res, "invalid_key")
 
         log = logs.entry
-        assert log["api_key"] == "invalid"
-        assert log["api_key"] != api_key.valid_key
+        assert log["api_key"] == api_key.valid_key
+        assert not log["api_key_allowed"]
 
     def test_blue_not_found(self, app, data_queues, metricsmock, logs):
         """A failed Bluetooth-based lookup emits several metrics."""

--- a/ichnaea/api/locate/tests/test_region_v1.py
+++ b/ichnaea/api/locate/tests/test_region_v1.py
@@ -10,6 +10,7 @@ class RegionBase(BaseLocateTest):
 
     url = "/v1/country"
     apikey_metrics = False
+    ip_log_and_rate_limit = False
     metric_path = "path:v1.country"
     metric_type = "region"
 

--- a/ichnaea/api/locate/tests/test_region_v1.py
+++ b/ichnaea/api/locate/tests/test_region_v1.py
@@ -56,7 +56,7 @@ class TestView(RegionBase, CommonLocateTest):
             "blue_valid": 0,
             "cell": 0,
             "cell_valid": 0,
-            "duration_s": logs.entry["duration_s"],
+            "duration_s": logs.only_entry["duration_s"],
             "event": "POST /v1/country - 200",
             "fallback_allowed": False,
             "has_geoip": True,
@@ -73,7 +73,7 @@ class TestView(RegionBase, CommonLocateTest):
             "wifi": 0,
             "wifi_valid": 0,
         }
-        assert logs.entry == expected_entry
+        assert logs.only_entry == expected_entry
 
     def test_geoip_miss(self, app, data_queues, metricsmock, logs):
         """GeoIP fails on some IPs, such as localhost."""
@@ -82,8 +82,8 @@ class TestView(RegionBase, CommonLocateTest):
         metricsmock.assert_incr_once(
             "request", tags=[self.metric_path, "method:post", "status:404"]
         )
-        assert logs.entry["source_geoip_accuracy"] is None
-        assert logs.entry["source_geoip_status"] == "miss"
+        assert logs.only_entry["source_geoip_accuracy"] is None
+        assert logs.only_entry["source_geoip_status"] == "miss"
 
     def test_incomplete_request(self, app, data_queues):
         res = self._call(app, body={"wifiAccessPoints": []}, ip=self.test_ip)

--- a/ichnaea/api/locate/tests/test_region_v1.py
+++ b/ichnaea/api/locate/tests/test_region_v1.py
@@ -36,7 +36,7 @@ class RegionBase(BaseLocateTest):
 
 
 class TestView(RegionBase, CommonLocateTest):
-    def test_geoip(self, app, data_queues, metricsmock):
+    def test_geoip(self, app, data_queues, metricsmock, logs):
         """GeoIP can be used to determine the region."""
         res = self._call(app, ip=self.test_ip)
         self.check_response(data_queues, res, "ok")
@@ -45,14 +45,44 @@ class TestView(RegionBase, CommonLocateTest):
         metricsmock.assert_incr_once(
             "request", tags=[self.metric_path, "method:post", "status:200"]
         )
+        expected_entry = {
+            "accuracy": "low",
+            "accuracy_min": "low",
+            "api_key": "test",
+            "api_path": "v1.country",
+            "api_type": "region",
+            "blue": 0,
+            "blue_valid": 0,
+            "cell": 0,
+            "cell_valid": 0,
+            "duration_s": logs.entry["duration_s"],
+            "event": "POST /v1/country - 200",
+            "fallback_allowed": False,
+            "has_geoip": True,
+            "has_ip": True,
+            "http_method": "POST",
+            "http_path": "/v1/country",
+            "http_status": 200,
+            "log_level": "info",
+            "region": "GB",
+            "result_status": "hit",
+            "source_geoip_accuracy": "low",
+            "source_geoip_accuracy_min": "low",
+            "source_geoip_status": "hit",
+            "wifi": 0,
+            "wifi_valid": 0,
+        }
+        assert logs.entry == expected_entry
 
-    def test_geoip_miss(self, app, data_queues, metricsmock):
+    def test_geoip_miss(self, app, data_queues, metricsmock, logs):
         """GeoIP fails on some IPs, such as localhost."""
         res = self._call(app, ip="127.0.0.1", status=404)
         self.check_response(data_queues, res, "not_found")
         metricsmock.assert_incr_once(
             "request", tags=[self.metric_path, "method:post", "status:404"]
         )
+        assert logs.entry["source_geoip_accuracy"] is None
+        assert logs.entry["source_geoip_status"] == "miss"
 
     def test_incomplete_request(self, app, data_queues):
         res = self._call(app, body={"wifiAccessPoints": []}, ip=self.test_ip)

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -182,6 +182,7 @@ class BaseSubmitTest(object):
         expected_entry = {
             "api_key": "test",
             "api_path": self.metric_path.split(":")[1],
+            "api_type": "submit",
             "duration_s": logs.entry["duration_s"],
             "event": f"POST {self.url} - {self.status}",
             "http_method": "POST",

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -140,7 +140,7 @@ class BaseSubmitTest(object):
             self.metric_type + ".request", tags=[self.metric_path, "key:none"]
         )
         assert redis.keys("apiuser:*") == []
-        assert logs.entry["api_key"] == "none"
+        assert logs.only_entry["api_key"] == "none"
 
     def test_log_api_key_invalid(self, app, redis, metricsmock, logs):
         cell, query = self._one_cell_query()
@@ -149,8 +149,8 @@ class BaseSubmitTest(object):
             self.metric_type + ".request", tags=[self.metric_path, "key:none"]
         )
         assert redis.keys("apiuser:*") == []
-        assert logs.entry["api_key"] == "none"
-        assert logs.entry["invalid_api_key"] == "invalid_key"
+        assert logs.only_entry["api_key"] == "none"
+        assert logs.only_entry["invalid_api_key"] == "invalid_key"
 
     def test_log_api_key_unknown(self, app, redis, metricsmock, logs):
         cell, query = self._one_cell_query()
@@ -159,8 +159,8 @@ class BaseSubmitTest(object):
             self.metric_type + ".request", tags=[self.metric_path, "key:invalid"]
         )
         assert redis.keys("apiuser:*") == []
-        assert logs.entry["api_key"] == "invalid"
-        assert logs.entry["invalid_api_key"] == "abcdefg"
+        assert logs.only_entry["api_key"] == "invalid"
+        assert logs.only_entry["invalid_api_key"] == "abcdefg"
 
     def test_log_stats(self, app, redis, metricsmock, logs):
         cell, query = self._one_cell_query()
@@ -185,14 +185,14 @@ class BaseSubmitTest(object):
             "api_key_repeat_ip": False,
             "api_path": self.metric_path.split(":")[1],
             "api_type": "submit",
-            "duration_s": logs.entry["duration_s"],
+            "duration_s": logs.only_entry["duration_s"],
             "event": f"POST {self.url} - {self.status}",
             "http_method": "POST",
             "http_path": self.url,
             "http_status": self.status,
             "log_level": "info",
         }
-        assert logs.entry == expected_entry
+        assert logs.only_entry == expected_entry
 
     def test_options(self, app):
         res = app.options(self.url, status=200)

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -182,7 +182,7 @@ class BaseSubmitTest(object):
         expected_entry = {
             "api_key": "test",
             "api_key_count": 1,
-            "api_key_ip_count": 1,
+            "api_key_repeat_ip": False,
             "api_path": self.metric_path.split(":")[1],
             "api_type": "submit",
             "duration_s": logs.entry["duration_s"],

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -181,6 +181,8 @@ class BaseSubmitTest(object):
         ]
         expected_entry = {
             "api_key": "test",
+            "api_key_count": 1,
+            "api_key_ip_count": 1,
             "api_path": self.metric_path.split(":")[1],
             "api_type": "submit",
             "duration_s": logs.entry["duration_s"],

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -150,6 +150,7 @@ class BaseSubmitTest(object):
         )
         assert redis.keys("apiuser:*") == []
         assert logs.entry["api_key"] == "none"
+        assert logs.entry["invalid_api_key"] == "invalid_key"
 
     def test_log_api_key_unknown(self, app, redis, metricsmock, logs):
         cell, query = self._one_cell_query()
@@ -159,6 +160,7 @@ class BaseSubmitTest(object):
         )
         assert redis.keys("apiuser:*") == []
         assert logs.entry["api_key"] == "invalid"
+        assert logs.entry["invalid_api_key"] == "abcdefg"
 
     def test_log_stats(self, app, redis, metricsmock, logs):
         cell, query = self._one_cell_query()

--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -86,9 +86,17 @@ class BaseAPIView(BaseView):
                 pipe.expire(log_ip_key, 691200)  # 8 days
                 pipe.incr(rate_key, 1)
                 pipe.expire(rate_key, 90000)  # 25 hours
-                _, _, count, _ = pipe.execute()
-                if maxreq and count > maxreq:
-                    should_limit = True
+                ip_count, _, limit_count, _ = pipe.execute()
+                log_params = {
+                    "api_key_count": limit_count,
+                    "api_key_ip_count": ip_count,
+                }
+                if maxreq:
+                    should_limit = limit_count > maxreq
+                    log_params["rate_quota"] = maxreq
+                    log_params["rate_remaining"] = max(0, maxreq - limit_count)
+                    log_params["rate_allowed"] = not should_limit
+                bind_threadlocal(**log_params)
         except RedisError:
             self.raven_client.captureException()
 

--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -54,7 +54,9 @@ class BaseAPIView(BaseView):
             self.view_type + ".request",
             tags=["path:" + self.metric_path, "key:" + valid_key],
         )
-        bind_threadlocal(api_path=self.metric_path, api_key=valid_key)
+        bind_threadlocal(
+            api_key=valid_key, api_path=self.metric_path, api_type=self.view_type
+        )
 
     def log_ip_and_rate_limited(self, valid_key, maxreq):
         # Log IP

--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -147,6 +147,12 @@ class BaseAPIView(BaseView):
                 # if we cannot connect to backend DB, skip api key check
                 skip_check = True
                 self.raven_client.captureException()
+                bind_threadlocal(
+                    api_key=api_key_text,
+                    api_path=self.metric_path,
+                    api_type=self.view_type,
+                    api_key_db_fail=True,
+                )
 
         if api_key is not None and api_key.allowed(self.view_type):
             valid_key = api_key.valid_key

--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -7,7 +7,9 @@ import json
 import colander
 from ipaddress import ip_address
 import markus
+from pymysql.err import DatabaseError
 from redis import RedisError
+from sqlalchemy.exc import DBAPIError
 from structlog.threadlocal import bind_threadlocal
 
 from ichnaea.api.exceptions import DailyLimitExceeded, InvalidAPIKey, ParseError
@@ -151,7 +153,7 @@ class BaseAPIView(BaseView):
         if api_key_text is not None:
             try:
                 api_key = get_key(self.request.db_session, api_key_text)
-            except Exception:
+            except (DatabaseError, DBAPIError):
                 # if we cannot connect to backend DB, skip api key check
                 skip_check = True
                 self.raven_client.captureException()

--- a/ichnaea/conftest.py
+++ b/ichnaea/conftest.py
@@ -531,7 +531,7 @@ class SingleLogCapture(LogCapture):
     """Capturing processor with helper method for single log entries."""
 
     @property
-    def entry(self):
+    def only_entry(self):
         """Assert there is a single log entry and return it."""
         assert len(self.entries) == 1
         return self.entries[0]

--- a/ichnaea/content/tests/test_views.py
+++ b/ichnaea/content/tests/test_views.py
@@ -134,17 +134,15 @@ class TestFunctionalContent(object):
             # App 404s like geolocate misses are logged, see API tests
             assert logs.entries == []
         else:
-            assert len(logs.entries) == 1
-            log = logs.entries[0]
             expected_log = {
-                "duration_s": log["duration_s"],
+                "duration_s": logs.only_entry["duration_s"],
                 "event": f"GET {path} - {status}",
                 "http_method": "GET",
                 "http_path": path,
                 "http_status": status,
                 "log_level": "info",
             }
-            assert log == expected_log
+            assert logs.only_entry == expected_log
 
     @config_override(ASSET_BUCKET="bucket", ASSET_URL="http://127.0.0.1:9/foo")
     def test_downloads(self, app):


### PR DESCRIPTION
Add a pytest fixture ``logs`` that captures the structured logging entries and makes them available for testing. Add full log entry tests for non-API views, basic successful API views, and some error cases. Add targeted log entry tests for API key validation, and some for location to demonstrate the additional testing capabilities.

This also changes the base API view to allow more log metrics:

* submit APIs now have ``api_type="submit"``
* For geolocate and submit APIs, usage metrics are added:
  - ``api_key_count``: Daily count of API usage by this key
  - ~``api_key_ip_count``~: ~Daily count of API usage by this key and IP~
  - ``api_key_repeat_ip``: True if we've seen this API key / IP combo today (using Redis [HyperLogLog](https://redislabs.com/redis-best-practices/counting/hyperloglog/))~
  - If an API key includes a maximum daily requests limit:
      * ``rate_quota``: (If rate limited) The maximum daily requests for this API key
      * ``rate_remaining``: (If rate limited) The remaining daily requests for this API key, 0 if none
      * ``rate_allowed``: (If rate limited) True if allowed, False if rate limited
* Rate-limiting metrics and the related code are skipped for the region API, to "potentially avoid overhead of Redis connection".
* ``invalid_api_key`` is set when the key in the request is invalid. This can happen when it fails validation (``api_key`` is ``"none"``), or when it is not in the API key table (``api_key`` is ``"invalid"``).
* ``api_key_db_fail=True`` when a database error prevents reading the API key table

