### PR TITLE
bug 1624687: Compute request signatures to identify repeats

### DIFF
--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -1,6 +1,7 @@
 TESTING=true
 MAPBOX_TOKEN=pk.123456
 ASSET_URL=http://127.0.0.1:9/static/
+SECRET_KEY=default for testing, change in production
 
 # Sets Redis to use "1" db
 REDIS_URI=redis://redis:6379/1

--- a/ichnaea/api/locate/query.py
+++ b/ichnaea/api/locate/query.py
@@ -183,7 +183,7 @@ class Query(object):
         If the same Bluetooth network is supplied multiple times, this
         chooses only the best entry for each unique network.
 
-        If fewer than :data:`~ichnaea.api.locate.constants.MIN_BLUSS_IN_QUERY`
+        If fewer than :data:`~ichnaea.api.locate.constants.MIN_BLUES_IN_QUERY`
         unique valid Bluetooth networks are found, returns an empty list.
         """
         return self._blue

--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -325,6 +325,8 @@ class CommonLocateTest(BaseLocateTest):
         if self.ip_log_and_rate_limit:
             expected_entry["api_key_count"] = 1
             expected_entry["api_key_repeat_ip"] = False
+            expected_entry["api_repeat_request"] = False
+            expected_entry["api_request_sig"] = logs.only_entry["api_request_sig"]
         assert logs.only_entry == expected_entry
 
     def test_options(self, app, logs):

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -743,17 +743,19 @@ class TestView(LocateV1Base, CommonLocateTest):
         if with_radio == "cell":
             cell1 = CellShardFactory(radio=Radio.lte)
             cell2 = CellShardFactory(radio=Radio.lte)
+            cell3 = CellShardFactory(radio=Radio.lte)
             query = self.model_query(cells=[cell1, cell2])
-            query_same = self.model_query(cells=[cell1, cell2])
-            query_same["fallbacks"] = {"lacf": True}
-            # Because lists are not sorted, although query_diff has the same
-            # data as query, it counts as a different query
-            # TODO: sort lists of cell, wifi, and bluetooth in schema serialization
-            query_diff = self.model_query(cells=[cell2, cell1])
+            # The same stations in a different order is the same query
+            query_same = self.model_query(cells=[cell2, cell1])
+            # Different stations make a different query
+            query_diff = self.model_query(cells=[cell1, cell3])
         else:
+            assert with_radio is None
             # IP-based lookup
             query = {}
+            # Explicitly setting a value to the default is the same query
             query_same = {"fallbacks": {"ipf": True}}
+            # Changing a setting from the default is a different query
             query_diff = {"fallbacks": {"lacf": False}}
 
         # Make two identical calls

--- a/ichnaea/api/submit/schema_v2.py
+++ b/ichnaea/api/submit/schema_v2.py
@@ -26,7 +26,7 @@ class SubmitV2Schema(OptionalMappingSchema):
         class SequenceItem(ReportSchema):
 
             cellTowers = CellTowersV2Schema(missing=())
-            position = PositionSchema(missing=None)
+            position = PositionSchema(missing=colander.drop)
 
 
 SUBMIT_V2_SCHEMA = SubmitV2Schema()

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -184,6 +184,8 @@ class BaseSubmitTest(object):
             "api_key_count": 1,
             "api_key_repeat_ip": False,
             "api_path": self.metric_path.split(":")[1],
+            "api_repeat_request": False,
+            "api_request_sig": logs.only_entry["api_request_sig"],
             "api_type": "submit",
             "duration_s": logs.only_entry["duration_s"],
             "event": f"POST {self.url} - {self.status}",

--- a/ichnaea/api/submit/tests/test_submit_v2.py
+++ b/ichnaea/api/submit/tests/test_submit_v2.py
@@ -293,3 +293,11 @@ class TestView(BaseSubmitTest):
             ],
         )
         assert self.queue(celery).size() == 3
+        item1, item2, item3 = self.queue(celery).dequeue()
+        assert set(item1["report"]["position"].keys()) == {
+            "latitude",
+            "longitude",
+            "accuracy",
+        }
+        assert set(item2["report"]["position"].keys()) == {"accuracy"}
+        assert "position" not in item3["report"]

--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -15,6 +15,7 @@ from structlog.threadlocal import bind_threadlocal
 
 from ichnaea.api.exceptions import DailyLimitExceeded, InvalidAPIKey, ParseError
 from ichnaea.api.key import get_key, Key, validated_key
+from ichnaea.conf import settings
 from ichnaea.exceptions import GZIPDecodeError
 from ichnaea import util
 from ichnaea.webapp.view import BaseView
@@ -158,6 +159,7 @@ class BaseAPIView(BaseView):
             client_addr = self.request.client_addr or "127.0.0.1"
             siggen.update(client_addr.encode())
             siggen.update(self.request.url.encode())  # Includes the API key if given
+            siggen.update(settings("secret_key").encode())
             signature = siggen.hexdigest()
             today = util.utcnow().date().isoformat()
             key = f"apirequest:{today}"

--- a/ichnaea/conf.py
+++ b/ichnaea/conf.py
@@ -112,6 +112,12 @@ class AppConfig(RequiredConfigMixin):
         doc="absolute path to mmdb file for GeoIP lookups",
     )
 
+    required_config.add_option(
+        "secret_key",
+        default="default for development, change in production",
+        doc="a unique passphrase used for cryptographic signing",
+    )
+
     def __init__(self, config):
         self.raw_config = config
         self.config = config.with_options(self)

--- a/ichnaea/conf.py
+++ b/ichnaea/conf.py
@@ -138,3 +138,35 @@ def build_config_manager():
 
 
 settings = build_config_manager()
+
+
+def is_dev_config():
+    """Return True if this appears to be the dev environment."""
+    dev_redis_uri = "redis://redis:6379/0"
+    redis_uri = settings("redis_uri")
+    return redis_uri == dev_redis_uri
+
+
+def check_config():
+    """If not in the dev environment, ensure settings are non-development."""
+    if is_dev_config():
+        return
+
+    issues = []
+
+    # These values should be non-empty and non-default
+    should_be_set = {"secret_key"}
+    for name in should_be_set:
+        default = settings.config.options.options[name].default
+        value = settings(name)
+        if value == default:
+            issues.append(f"{name} has the default value '{value}'")
+        elif not value:
+            issues.append(f"{name} is not set")
+
+    if issues:
+        message = (
+            "redis_url has a non-development value, but there are issues"
+            " with settings: " + ", ".join(issues)
+        )
+        raise RuntimeError(message)

--- a/ichnaea/webapp/config.py
+++ b/ichnaea/webapp/config.py
@@ -11,6 +11,7 @@ from ichnaea.api.locate.searcher import (
     configure_region_searcher,
 )
 from ichnaea.cache import configure_redis
+from ichnaea.conf import check_config
 from ichnaea.content.views import configure_content
 from ichnaea.db import configure_db, db_session, db_worker_session, ping_session
 from ichnaea.geoip import configure_geoip
@@ -53,6 +54,7 @@ def main(
     configure_logging()
 
     config = Configurator()
+    check_config()
 
     # add support for pt templates
     config.include("pyramid_chameleon")


### PR DESCRIPTION
To make progress on [bug 1624687](https://bugzilla.mozilla.org/show_bug.cgi?id=1624687), we need a way to detect and quantify repeated requests.

First, I considered using ``Query.json()`` to create a signature that reflected the way the app sees a request, rather than the details of the request itself. This turned out to be a bad idea, because:

1. It didn't extend well to submits and
2. Data that doesn't meet privacy thresholds is discarded. For example, a request with a single WiFi radio is a geolocate miss and the output from ``.json()`` looks the same as an empty request.

I kept the tests that led me to this conclusion, since there were no specific tests for the ``.json()`` method yet.

Instead, I use the ``preprocess_request`` method, shared with all API methods, to take a hash of:
* The request body, after any gzip decompression and charset decoding
* The IP address, which can determine a GeoIP response, and
* The URL, which would include the API key

I use SHA-512 because, according to the [Wikipedia page](https://en.wikipedia.org/wiki/Cryptographic_hash_function#SHA-2), "SHA-512 is more secure than SHA-256 and is commonly faster than SHA-256 on 64 bit machines such as AMD64".

I then use [PFADD](https://redis.io/commands/pfadd) to track if we've seen that signature before, adding two log metrics:
* ``api_repeat_request``: True if we've seen this signature before
* ``api_request_sig``: The first 8 hex characters of the hash

The way I see using this is:
* Count ``api_repeat_request==True`` and ``api_repeat_request==False``, to determine the ratio of repeat to unique requests
* Generate a histogram of ``api_request_sig`` counts to identify users that could benefit from caching.