### PR TITLE
bug 1635789 - Add SECRET_KEY, response signature

### DIFF
--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -1,6 +1,7 @@
 TESTING=true
 MAPBOX_TOKEN=pk.123456
 ASSET_URL=http://127.0.0.1:9/static/
+SECRET_KEY=default for testing, change in production
 
 # Sets Redis to use "1" db
 REDIS_URI=redis://redis:6379/1

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -137,6 +137,7 @@ for example called `env.txt`:
     DB_PASSWORD=secret
     GEOIP_PATH=/app/geoip/GeoLite2-City.mmdb
     REDIS_HOST=domain.name.for.redis
+    SECRET_KEY=change_this_value_or_it_will_not_be_secret
 
 You can use either a single database user with DDL/DML privileges
 (`DB_USER` / `DB_PASSWORD`) or separate users for DDL, read-write and

--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -293,6 +293,7 @@ class CommonLocateTest(BaseLocateTest):
             "request.timing", tags=[self.metric_path, "method:get"]
         )
 
+        log = logs.only_entry
         expected_entry = {
             # accuracy is low for region API fixture, and medium for geolocate
             # see bound_model_accuracy and related tests for direct calculation
@@ -305,7 +306,7 @@ class CommonLocateTest(BaseLocateTest):
             "blue_valid": 0,
             "cell": 0,
             "cell_valid": 0,
-            "duration_s": logs.only_entry["duration_s"],
+            "duration_s": log["duration_s"],
             "event": f"GET {self.url} - 200",
             "fallback_allowed": False,
             "has_geoip": True,
@@ -316,16 +317,18 @@ class CommonLocateTest(BaseLocateTest):
             "log_level": "info",
             "region": "GB",
             "result_status": "hit",
-            "source_geoip_accuracy": logs.only_entry["accuracy"],
+            "source_geoip_accuracy": log["accuracy"],
             "source_geoip_accuracy_min": "low",
             "source_geoip_status": "hit",
             "wifi": 0,
             "wifi_valid": 0,
         }
-        if self.ip_log_and_rate_limit:
+        if self.metric_type == "locate":
             expected_entry["api_key_count"] = 1
             expected_entry["api_key_repeat_ip"] = False
-        assert logs.only_entry == expected_entry
+            expected_entry["api_repeat_response"] = False
+            expected_entry["api_response_sig"] = log["api_response_sig"]
+        assert log == expected_entry
 
     def test_options(self, app, logs):
         """An OPTIONS request works, as required for CORS"""

--- a/ichnaea/tests/test_conf.py
+++ b/ichnaea/tests/test_conf.py
@@ -1,0 +1,53 @@
+"""Tests for ichnaea.conf"""
+
+from unittest import mock
+
+from everett.manager import config_override
+import pytest
+
+from ichnaea.conf import check_config, is_dev_config
+
+
+class TestIsDevConfig:
+    """Tests for ichnaea.conf.is_dev_config()"""
+
+    def test_testing(self):
+        """The testing config is non-development."""
+        assert not is_dev_config()
+
+    def test_is_dev(self):
+        """The REDIS_URI is used to determine if we're in development."""
+        with config_override(REDIS_URI="redis://redis:6379/0"):
+            assert is_dev_config()
+
+
+SECRET_KEY_DEFAULT = "default for development, change in production"
+
+
+class TestCheckConfig:
+    """Tests for ichnaea.conf.check_config()"""
+
+    def test_testing(self):
+        """The testing configuration passes."""
+        check_config()
+
+    @pytest.mark.parametrize("secret_key", ("", SECRET_KEY_DEFAULT, "other"))
+    def test_dev_any_secret_key(self, secret_key):
+        with mock.patch("ichnaea.conf.is_dev_config", return_value=True):
+            with config_override(SECRET_KEY=secret_key):
+                check_config()
+
+    def test_not_dev_fails_with_blank_secret_key(self):
+        with mock.patch("ichnaea.conf.is_dev_config", return_value=False):
+            with config_override(SECRET_KEY=""):
+                with pytest.raises(RuntimeError) as e:
+                    check_config()
+                assert e.value.args[0].endswith("secret_key is not set")
+
+    def test_not_dev_fails_with_default_key(self):
+        with mock.patch("ichnaea.conf.is_dev_config", return_value=False):
+            with config_override(SECRET_KEY=SECRET_KEY_DEFAULT):
+                with pytest.raises(RuntimeError) as e:
+                    check_config()
+                expected = f"secret_key has the default value '{SECRET_KEY_DEFAULT}'"
+                assert e.value.args[0].endswith(expected)

--- a/ichnaea/util.py
+++ b/ichnaea/util.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from datetime import datetime
 import gzip
+from hashlib import sha512
 from itertools import zip_longest
 import json
 import os
@@ -12,6 +13,7 @@ import zlib
 
 from pytz import UTC
 
+from ichnaea.conf import settings
 from ichnaea.exceptions import GZIPDecodeError
 
 HERE = os.path.dirname(__file__)
@@ -112,3 +114,19 @@ def print_table(table, delimiter=" | ", stream_write=sys.stdout.write):
             )
             + "\n"
         )
+
+
+def generate_signature(reason, *parts):
+    """
+    Generate a salted signature for a set of strings.
+
+    :arg reason A short "why" string used to salt the hash
+    :arg parts A list of strings to add to the signature
+    """
+    siggen = sha512()
+    for part in parts:
+        if part:
+            siggen.update(part.encode())
+    siggen.update(reason.encode())
+    siggen.update(settings("secret_key").encode())
+    return siggen.hexdigest()

--- a/ichnaea/webapp/config.py
+++ b/ichnaea/webapp/config.py
@@ -11,6 +11,7 @@ from ichnaea.api.locate.searcher import (
     configure_region_searcher,
 )
 from ichnaea.cache import configure_redis
+from ichnaea.conf import check_config
 from ichnaea.content.views import configure_content
 from ichnaea.db import configure_db, db_session, db_worker_session, ping_session
 from ichnaea.geoip import configure_geoip
@@ -53,6 +54,7 @@ def main(
     configure_logging()
 
     config = Configurator()
+    check_config()
 
     # add support for pt templates
     config.include("pyramid_chameleon")


### PR DESCRIPTION
Add a ``SECRET_KEY`` configuration setting, used in a similar way to Django's [SECRET_KEY](https://docs.djangoproject.com/en/3.0/ref/settings/#secret-key) as a cryptographic hashing salt. If the web server detects it is not in the development environment, it fails if ``SECRET_KEY`` is set to the non-default value.

Use it to create a response signature, which will be the same for the same combo of response JSON, client IP, API path, and API key. Use [Redis PFADD](https://redis.io/commands/pfadd) to detect unique and repeated responses. Add two new log metrics:
* ``api_repeat_response`` - ``True`` if this response was repeated
* ``api_response_sig`` - The first 8 hex digits of the response signature