### PR TITLE
bug 1635789: Count repeated responses per API key

### DIFF
--- a/ichnaea/api/locate/views.py
+++ b/ichnaea/api/locate/views.py
@@ -91,7 +91,7 @@ class LocateV1View(BasePositionView):
             pipe.expire(key, 90000)  # 25 hours
             new_response, _ = pipe.execute()
         bind_threadlocal(
-            api_repeat_response=not new_response, api_response_sig=response_sig[:8]
+            api_repeat_response=not new_response, api_response_sig=response_sig[:16]
         )
 
         return response


### PR DESCRIPTION
Collecting all responses in a single [PFADD](https://redis.io/commands/pfadd) structure lead to a high percentage of false positives for API keys with relatively low traffic. Splitting by API type and API key mirrors the `PFADD` structure used to [detect repeated IP addresses](https://github.com/mozilla/ichnaea/blob/7a7ad8d7f81edc21b8e71573746dbb5004fb072d/ichnaea/api/views.py#L76-L79), and should be more accurate for the long tail of API keys.

When using the single `PFADD`, there is a high percent of "bizarre" requests, where `api_key_repeat_ip` is False (this IP has not been seen today for this API / API Key) but `api_repeat_response` is True (this IP requested with this API / API Key and got the same response). Overall, 0.07% of the responses are bizarre, and 0.03% of the GeoClue responses, which seems acceptable for the accuracy of `PFADD` cardinality estimate. However, for the FF desktop key, 7% of responses are bizarre, and over 50% are bizarre for some API keys with less than 50 requests.

Tests didn't change because the signatures are still the same, and the `PFADD` / [PFCOUNT](https://redis.io/commands/pfcount) doesn't switch to HyperLogLog estimates until you get into the range of 10,000 unique items.