### PR TITLE
bug 1635789: Remove PFADD log metrics

### DIFF
--- a/ichnaea/api/locate/tests/base.py
+++ b/ichnaea/api/locate/tests/base.py
@@ -325,8 +325,6 @@ class CommonLocateTest(BaseLocateTest):
         }
         if self.metric_type == "locate":
             expected_entry["api_key_count"] = 1
-            expected_entry["api_key_repeat_ip"] = False
-            expected_entry["api_repeat_response"] = False
             expected_entry["api_response_sig"] = log["api_response_sig"]
         assert log == expected_entry
 

--- a/ichnaea/api/locate/tests/test_locate_v1.py
+++ b/ichnaea/api/locate/tests/test_locate_v1.py
@@ -111,7 +111,6 @@ class TestView(LocateV1Base, CommonLocateTest):
         expected_entry = {
             "api_key": api_key.valid_key,
             "api_key_count": 11,
-            "api_key_repeat_ip": False,
             "api_path": self.metric_path.split(":")[1],
             "api_type": self.metric_type,
             "duration_s": logs.only_entry["duration_s"],
@@ -738,7 +737,7 @@ class TestView(LocateV1Base, CommonLocateTest):
         self.check_model_response(res, cell)
 
     def test_signature(self, app, session, redis, logs):
-        """Identical requests have the same signature, repeats are noticed."""
+        """Identical requests have the same signature."""
 
         # Make two identical calls
         self._call(app, api_key="test", ip=self.test_ip)
@@ -759,21 +758,13 @@ class TestView(LocateV1Base, CommonLocateTest):
         # First two calls have identical signatures
         assert log1["api_response_sig"] == log2["api_response_sig"]
         seen_sigs = set([log1["api_response_sig"]])
-        assert not log1["api_key_repeat_ip"]
-        assert not log1["api_repeat_response"]
-        assert log2["api_key_repeat_ip"]
-        assert log2["api_repeat_response"]
 
         # A different IP has a different signature
         assert log_new_ip["api_response_sig"] not in seen_sigs
         seen_sigs.add(log_new_ip["api_response_sig"])
-        assert not log_new_ip["api_key_repeat_ip"]
-        assert not log_new_ip["api_repeat_response"]
 
         # A different API key has a different signature
         assert log_new_key["api_response_sig"] not in seen_sigs
-        assert not log_new_key["api_key_repeat_ip"]
-        assert not log_new_key["api_repeat_response"]
 
 
 class TestError(LocateV1Base, BaseLocateTest):
@@ -793,7 +784,6 @@ class TestError(LocateV1Base, BaseLocateTest):
             "api_key": "test",
             "api_key_db_fail": True,
             "api_path": "v1.geolocate",
-            "api_repeat_response": False,
             "api_response_sig": log["api_response_sig"],
             "api_type": "locate",
             "blue": 0,
@@ -856,9 +846,7 @@ class TestError(LocateV1Base, BaseLocateTest):
             "accuracy_min": "high",
             "api_key": "test",
             "api_key_count": 1,
-            "api_key_repeat_ip": False,
             "api_path": "v1.geolocate",
-            "api_repeat_response": False,
             "api_response_sig": log["api_response_sig"],
             "api_type": "locate",
             "blue": 0,

--- a/ichnaea/api/locate/views.py
+++ b/ichnaea/api/locate/views.py
@@ -10,7 +10,7 @@ from ichnaea.api.exceptions import LocationNotFound
 from ichnaea.api.locate.schema_v1 import LOCATE_V1_SCHEMA
 from ichnaea.api.locate.query import Query
 from ichnaea.api.views import BaseAPIView
-from ichnaea.util import generate_signature, utcnow
+from ichnaea.util import generate_signature
 
 
 class BaseLocateView(BaseAPIView):
@@ -84,15 +84,7 @@ class LocateV1View(BasePositionView):
             self.request.client_addr,
             self.request.url,  # Includes the API, API key
         )
-        today = utcnow().date().isoformat()
-        key = f"response-sig:{self.view_type}:{api_key.valid_key}:{today}"
-        with self.redis_client.pipeline() as pipe:
-            pipe.pfadd(key, response_sig)
-            pipe.expire(key, 90000)  # 25 hours
-            new_response, _ = pipe.execute()
-        bind_threadlocal(
-            api_repeat_response=not new_response, api_response_sig=response_sig[:16]
-        )
+        bind_threadlocal(api_response_sig=response_sig[:16])
 
         return response
 

--- a/ichnaea/api/submit/tests/base.py
+++ b/ichnaea/api/submit/tests/base.py
@@ -182,7 +182,6 @@ class BaseSubmitTest(object):
         expected_entry = {
             "api_key": "test",
             "api_key_count": 1,
-            "api_key_repeat_ip": False,
             "api_path": self.metric_path.split(":")[1],
             "api_type": "submit",
             "duration_s": logs.only_entry["duration_s"],

--- a/ichnaea/api/views.py
+++ b/ichnaea/api/views.py
@@ -88,10 +88,9 @@ class BaseAPIView(BaseView):
                 pipe.expire(log_ip_key, 691200)  # 8 days
                 pipe.incr(rate_key, 1)
                 pipe.expire(rate_key, 90000)  # 25 hours
-                new_ip, _, limit_count, _ = pipe.execute()
+                _, _, limit_count, _ = pipe.execute()
             log_params = {
                 "api_key_count": limit_count,
-                "api_key_repeat_ip": new_ip == 0,
             }
             if maxreq:
                 should_limit = limit_count > maxreq


### PR DESCRIPTION
The metrics ``api_key_repeat_ip`` and ``api_repeat_response`` are based on the
return from [PFADD](https://redis.io/commands/pfadd), used to estimate the number of daily unique IP addresses and responses. After further research, this does not signify if a value is a repeat, but if the estimated cardinality has changed. This is less and less frequent as the cardinality increases, exceeding 99% at 100 million items. This is not a useful metric to track.

The cardinality of the IP addresses is useful, so the related ``PFADD`` call is retained, without capturing the return. The [PFCOUNT](https://redis.io/commands/pfcount) return, accurate to about 1%, is still sent [as an operational metric](https://github.com/mozilla/ichnaea/blob/b3f523a8bc6bc20f310317b7cd19c45c460edd15/ichnaea/data/monitor.py#L56-L62).

The cardinality of unique responses is not useful, so the related `PFADD` call is removed. The signature may still be useful in BigQuery analysis (such as on [bug 1635789](https://bugzilla.mozilla.org/show_bug.cgi?id=1635789)), so we keep it for now as a log metric.