### PR TITLE
bug 1647364: Switch default branch from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,14 +92,14 @@ jobs:
               if [ -n "${CIRCLE_TAG}" ]; then
                 export DOCKER_TAG="${CIRCLE_TAG}"
               fi
-              # push on master or git tag
-              if [ "${CIRCLE_BRANCH}" == "master" ] || [ -n "${CIRCLE_TAG}" ]; then
+              # push on main or git tag
+              if [ "${CIRCLE_BRANCH}" == "main" ] || [ -n "${CIRCLE_TAG}" ]; then
                 echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
                 docker tag "local/ichnaea_app" "mozilla/location:${DOCKER_TAG}"
                 retry docker push "mozilla/location:${DOCKER_TAG}"
 
-                # push `latest` on master only
-                if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                # push `latest` on main only
+                if [ "${CIRCLE_BRANCH}" == "main" ]; then
                   docker tag "local/ichnaea_app" "mozilla/location:latest"
                   retry docker push "mozilla/location:latest"
                 fi

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,7 +4,10 @@ How to contribute
 
 We gladly accept outside contributions.
 
-We use our `Github issue tracker <https://github.com/mozilla/ichnaea/issues>`_
+We use
+`Bugzilla <https://bugzilla.mozilla.org/buglist.cgi?product=Location&component=General&bug_status=__open__>`_
+and our
+`Github issue tracker <https://github.com/mozilla/ichnaea/issues>`_
 for both discussions and talking about new features or bugs. You can
 also fork the project and send us a pull request.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -32,5 +32,5 @@ Legal
 
 Currently we don't have any legal contributor agreement, so code
 ownership stays with the original authors. The project is licensed
-under the `Apache License Version 2
-<https://github.com/mozilla/ichnaea/blob/master/LICENSE>`_.
+under the
+`Apache License Version 2 <https://github.com/mozilla/ichnaea/blob/main/LICENSE>`_.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -20,8 +20,7 @@ about the accuracy of the results or the availability of the service.
 Please make sure that you actually need the raw API access to
 perform geolocation lookups. If you just need to get location data
 from your web application, you can directly use the
-`HTML5 API
-<https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation>`_.
+`HTML5 API <https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API>`_.
 
 To apply for an API key, please
 `fill out this form

--- a/docs/api/region.rst
+++ b/docs/api/region.rst
@@ -9,7 +9,7 @@ Region: /v1/country
 Bluetooth, cell, or WiFi networks the IP address used to access the service.
 
 The responses use region codes and names from the `GENC dataset
-<http://www.gwg.nga.mil/ccwg.php>`_, which is mostly compatible with the ISO
+<https://nsgreg.nga.mil/genc/discovery>`_, which is mostly compatible with the ISO
 3166 standard.
 
 .. Note::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ sys.modules['shapely'] = mock.MagicMock()
 
 
 project = 'Ichnaea'
-copyright = '2013-2019, Mozilla'
+copyright = '2013-2020, Mozilla'
 
 # The short X.Y version.
 version = '2.0'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,6 @@ exclude_patterns = ['_build', '.DS_Store', 'Thumbs.db']
 html_static_path = []
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-master_doc = 'index'
 modindex_common_prefix = ['ichnaea.']
 pygments_style = 'sphinx'
 source_suffix = '.rst'
@@ -46,4 +45,4 @@ def linkcode_resolve(domain, info):
     if not info['module']:
         return None
     filename = info['module'].replace('.', '/')
-    return "https://github.com/mozilla/ichnaea/tree/master/%s.py" % filename
+    return "https://github.com/mozilla/ichnaea/tree/main/%s.py" % filename

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -107,10 +107,10 @@ Mapbox
 The web site content uses Mapbox to generate tiles. In order to do this,
 it requires a Mapbox API token.
 
-You can create an account on their site: https://mapbox.com/
+You can create an account on their site: https://www.mapbox.com
 
 After you have an account, you can create an API token at:
-https://accounts.mapbox.com/
+https://account.mapbox.com
 
 Set the ``MAP_TOKEN`` configuration value to your API token.
 

--- a/docs/dataflows.rst
+++ b/docs/dataflows.rst
@@ -52,7 +52,7 @@ Data flow:
 
 3. The Celery scheduler schedules the ``update_incoming`` task every 
    X seconds--see task definition in `ichnaea/data/tasks.py
-   <https://github.com/mozilla/ichnaea/blob/master/ichnaea/data/tasks.py>`_.
+   <https://github.com/mozilla/ichnaea/blob/main/ichnaea/data/tasks.py>`_.
 
 4. A Celery worker executes the ``update_incoming`` task.
 

--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -124,7 +124,7 @@ Task Worker
 
 The asynchronous task worker uses a Python framework called Celery. You can use
 the `Celery monitoring guide
-<https://celery.readthedocs.io/en/latest/userguide/monitoring.html>`_ for more
+<https://docs.celeryproject.org/en/latest/userguide/monitoring.html>`_ for more
 detailed information.
 
 A basic test is to call the ``inspect stats`` commands. Open a shell container

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -178,8 +178,9 @@ It works both with the commerically available and Open-Source GeoLite
 databases in binary format.
 
 You can download the
-`GeoLite database <https://dev.maxmind.com/geoip/geoip2/geolite2/>`_ from
-https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz
+`GeoLite database <https://dev.maxmind.com/geoip/geoip2/geolite2/>`_ 
+for free from MaxMind after
+`signing up for a GeoLite2 account <https://www.maxmind.com/en/geolite2/signup>`_.
 
 Download and untar the downloaded file. Put the `GeoLite2-City.mmdb`
 into a directory accessible to docker (for example `/opt/geoip`).

--- a/docs/local_dev.rst
+++ b/docs/local_dev.rst
@@ -97,7 +97,7 @@ Updating code
 -------------
 
 Any time you want to update the code in the repostory, run something like this from
-the master branch::
+the main branch::
 
     $ git pull
 

--- a/ichnaea/taskapp/config.py
+++ b/ichnaea/taskapp/config.py
@@ -27,8 +27,8 @@ TASK_QUEUES = (
 def configure_celery(celery_app):
     """
     Configure the celery app stored in :data:`ichnaea.taskapp.app.celery_app`.
-    This is executed both inside the master worker process and once in
-    each forked worker process.
+    This is executed both inside the supervisor worker process and once in
+    each child / thread worker process.
 
     This parses the application ini and reads in the
     :mod:`ichnaea.taskapp.settings`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,4 @@ main_branch = main
 [tool:paul-mclendahand]
 github_user = mozilla
 github_project = ichnaea
+main_branch = main

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ universal=0
 ignore =
     # E203: Whitespace before ':'; doesn't work with black
     E203,
+    # E501: line too long; sometimes black doesn't split long strings
+    E501,
     # W503: line break before operator; this doesn't work with black
     W503
 exclude =
@@ -12,7 +14,7 @@ exclude =
     __pycache__,
     docs/,
     vendor/,
-    geocalclib/
+    geocalclib/,
 max-line-length = 88
 
 [tool:pytest]
@@ -27,6 +29,7 @@ github_user = mozilla
 github_project = ichnaea
 bugzilla_product = Location
 bugzilla_component = General
+main_branch = main
 
 [tool:paul-mclendahand]
 github_user = mozilla


### PR DESCRIPTION
Update the configuration and documentation for today's change of making the new `main` branch the default branch (see [this blog post](https://www.hanselman.com/blog/EasilyRenameYourGitDefaultBranchFromMasterToMain.aspx), as well as some other updates:

* In CircleCI, take special actions like uploading docker images on the `main` rather than `master` branch
* Update `bin/release.py` to latest version that supports different default branches, plus a line length change
* Update documentation references and code comments to the `main` branch of Ichnaea
* Bump copyright to 2020
* Fix some URLs and surrounding docs that failed `make linkcheck` validation


Addition, non-code changes are also needed, see [bug 1647364](https://bugzilla.mozilla.org/show_bug.cgi?id=1647364) for tracking.


