### PR TITLE
bug 1647364: Add master_doc to config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ exclude_patterns = ['_build', '.DS_Store', 'Thumbs.db']
 html_static_path = []
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+master_doc = 'index'
 modindex_common_prefix = ['ichnaea.']
 pygments_style = 'sphinx'
 source_suffix = '.rst'


### PR DESCRIPTION
readthedocs.org builds with Sphinx v1.8.5, and `master_doc` defaults to `'contents'` before Sphinx v2.0. This sets `master_doc='index'`, the Sphinx v2.0 and later default.

Alternatively, we could refactor the documentation dependencies into a new file, so that RTD gets the same version of Sphinx as the development environment.

Follow-on work for [bug 1647364](https://bugzilla.mozilla.org/show_bug.cgi?id=1647364) and PR #1220.