### PR TITLE
bug 1647364: Use the new refactored requirements/docs.txt

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
+  version: 3.8
   install:
-    - requirements: docs/requirements.txt
+    - requirements: requirements/docs.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-# NOTE(willkg): Minimal set of dependencies required to make the docs in
-# ReadTheDocs. There will be some duplicates between here and requirements/,
-# but it seems easier to live with that than orchestrating a setup where there
-# are no duplicates.
-#
-# We don't use hashes so that pip install will pick up dependencies and
-# therefore we can specify less. This is just for building docs on ReadTheDocs.
-everett==1.0.2
-sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
I missed that we already had a solution that installed requirements. This builds on PR #1222, to switch the ReadTheDocs config to use the new refactored ``requirements/docs.txt``.