### PR TITLE
run lint over specific directories, fix black issues

### DIFF
--- a/docker/run_lint.sh
+++ b/docker/run_lint.sh
@@ -13,6 +13,7 @@
 set -e
 
 BLACKARGS=("--line-length=88" "--target-version=py37" bin docker ichnaea)
+DIRS="ichnaea bin geocalclib docs"
 
 if [[ $1 == "--fix" ]]; then
     echo ">>> black fix"
@@ -21,8 +22,8 @@ if [[ $1 == "--fix" ]]; then
 else
     echo ">>> flake8 ($(python --version))"
     cd /app
-    flake8
+    flake8 ${DIRS}
 
     echo ">>> black"
-    black --check "${BLACKARGS[@]}"
+    black --check "${BLACKARGS[@]}" ${DIRS}
 fi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,44 +11,45 @@ sys.path.append(REPO_DIR)
 
 
 # Fake the shapely module so things will import
-sys.modules['shapely'] = mock.MagicMock()
+sys.modules["shapely"] = mock.MagicMock()
 
 
-project = 'Ichnaea'
-copyright = '2013-2020, Mozilla'
+project = "Ichnaea"
+copyright = "2013-2020, Mozilla"
 
 # The short X.Y version.
-version = '2.0'
+version = "2.0"
 # The full version, including alpha/beta/rc tags.
-release = '2.0'
+release = "2.0"
 
-autoclass_content = 'class'
-exclude_patterns = ['_build', '.DS_Store', 'Thumbs.db']
+autoclass_content = "class"
+exclude_patterns = ["_build", ".DS_Store", "Thumbs.db"]
 html_static_path = []
-modindex_common_prefix = ['ichnaea.']
-pygments_style = 'sphinx'
-source_suffix = '.rst'
-templates_path = ['_templates']
+modindex_common_prefix = ["ichnaea."]
+pygments_style = "sphinx"
+source_suffix = ".rst"
+templates_path = ["_templates"]
 
 # Use default theme if we are in ReadTheDocs
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
+on_rtd = os.environ.get("READTHEDOCS") == "True"
 if on_rtd:
-    html_theme = 'default'
+    html_theme = "default"
 else:
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 extensions = [
-    'sphinx.ext.linkcode',
-    'everett.sphinxext',
+    "sphinx.ext.linkcode",
+    "everett.sphinxext",
 ]
 
 
 def linkcode_resolve(domain, info):
-    if domain != 'py':
+    if domain != "py":
         return None
-    if not info['module']:
+    if not info["module"]:
         return None
-    filename = info['module'].replace('.', '/')
+    filename = info["module"].replace(".", "/")
     return "https://github.com/mozilla/ichnaea/tree/main/%s.py" % filename

--- a/geocalclib/setup.py
+++ b/geocalclib/setup.py
@@ -9,14 +9,14 @@ import numpy
 numpy_include = numpy.get_include()
 ext_modules = [
     Extension(
-        name='geocalc',
-        sources=['geocalc.c'],
+        name="geocalc",
+        sources=["geocalc.c"],
         include_dirs=[numpy_include],
     ),
 ]
 
 setup(
-    name='geocalc',
+    name="geocalc",
     license="Apache 2.0",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
@@ -27,7 +27,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Framework :: Pyramid",
         "Topic :: Internet :: WWW/HTTP",
-        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application"
+        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
I keep my Python virtualenvs in the root of the repository, so a bare `pyflakes8` or `black` will try to lint everything I have installd -- no fun.

It seems like black skips a few files by default, too, that are now covered, and are updated in this PR (just changing quote symbols).