### PR TITLE
1632621: Rewrite metrics doc for structured logs

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -12,7 +12,7 @@ Ichnaea provides two classes of runtime data:
 Structured logs were added in 2020, and the migration of data from metrics to
 logs is not complete. For more information, see the Implementation_ section.
 
-Metrics are emitted by the web / API application, the async task application,
+Metrics are emitted by the web / API application, the backend task application,
 and the datamaps script:
 
 ================================ ======== ======= =======================================================
@@ -71,10 +71,11 @@ some static content like ``robots.txt``.
 Additionally, invalid requests (HTTP status in the ``4xx`` range) do not omit this
 metric, unless they are API endpoints.
 
-The request path, like ``/stats/regions``, is normalized to tag-safe characters
-and included as the ``path`` tag. The initial slash is dropped, and remaining
-slashes are replaced with periods, so ``/stats/regions`` becomes ``stats.regions``.
-The homepage, ``/`` is normalized as ``.homepage``, to avoid an empty tag value.
+The ``path`` tag is the request path, like ``/stats/regions``, but normalized
+to tag-safe characters.  The initial slash is dropped, and remaining slashes
+are replaced with periods, so ``/stats/regions`` becomes ``stats.regions``.
+The homepage, ``/`` is normalized as ``.homepage``, to avoid an empty tag
+value.
 
 Tags:
 
@@ -120,7 +121,7 @@ Tags:
 
 Related structured log data:
 
-* `api_key`_: same value as tag ``key`` for valid keys
+* `api_key`_: The same value as tag ``key`` for valid keys
 
 locate.query
 ^^^^^^^^^^^^
@@ -132,8 +133,8 @@ contained in the request body.
 Tags:
 
 * ``key``: The API key, often a UUID
-* ``geoip``: omitted when there is GeoIP data for the client IP (common case),
-  ``false`` if there was no GeoIP data
+* ``geoip``: ``false`` if there was no GeoIOP data, and omitted when there is
+  GeoIP data for the client IP (the common case)
 * ``blue``: Count of valid Bluetooth :term:`stations` in the request, ``none``, ``one``
   or ``many``
 * ``cell``: Count of valid cell :term:`stations` in the request, ``none``, ``one``, or
@@ -146,7 +147,7 @@ Tags:
 
 Related structured log data:
 
-* `api_key`_: same value as tag ``key``
+* `api_key`_: The same value as tag ``key``
 * `has_geoip`_: Always set, ``False`` when ``geoip`` is ``false``
 * `blue`_: Count of Bluetooth stations, as a number instead of text like ``many``
 * `cell`_: Count of Cell stations
@@ -165,11 +166,11 @@ Tags:
 
 Related structured log data:
 
-* `api_key`_: same value as tag ``key``, except that instead of ``invalid``,
+* `api_key`_: The same value as tag ``key``, except that instead of ``invalid``,
   the request key is used, and ``api_key_allowed=False``
 * `api_key_allowed`_: ``False`` when the key is not allowed to use the API
-* `api_path`_: same value as tag ``path``
-* `api_type`_: value set to ``locate``
+* `api_path`_: The same value as tag ``path``
+* `api_type`_: The value ``locate``
 
 locate.result
 ^^^^^^^^^^^^^
@@ -201,26 +202,26 @@ Tags:
 
 * ``source``: The source that provided the hit:
 
-  - omitted when ``status=miss``
   - ``internal``: Our crowd-sourced network data
   - ``geoip``: The MaxMind GeoIP database
   - ``fallback``: An optional external fallback provider
+  - Omitted when ``status=miss``
 
 * ``fallback_allowed``:
 
-  - omitted if the external fallback provider was not allowed
   - ``true`` if the external fallback provider was allowed
+  - Omitted if the external fallback provider was not allowed
 
 .. versionchanged:: 2020.04.16
    Removed the ``region`` tag
 
 Related structured log data:
 
-* :ref:`accuracy <accuracy_metric>`: accuracy level of the result, ``high``,
+* :ref:`accuracy <accuracy_metric>`: The accuracy level of the result, ``high``,
   ``medium``, or ``low``
-* `accuracy_min`_: same value as tag ``accuracy``
-* `api_key`_: same value as tag ``key``
-* `result_status`_: same value as tag ``status``
+* `accuracy_min`_: The same value as tag ``accuracy``
+* `api_key`_: The same value as tag ``key``
+* `result_status`_: The same value as tag ``status``
 
 locate.source
 ^^^^^^^^^^^^^
@@ -247,8 +248,8 @@ Tags (similar to `locate.result`_) :
 
 * ``status``: Could we provide a location estimate?
 
-  - ``hit`` if we can provide a location with the expected accuracy,
-  - ``miss`` if we can not provide a location with the expected accuracy
+  - ``hit``: We can provide a location with the expected accuracy,
+  - ``miss``: We can not provide a location with the expected accuracy
 
 * ``source``: The source that was processed:
 
@@ -258,27 +259,27 @@ Tags (similar to `locate.result`_) :
 
 * ``fallback_allowed``:
 
-  - omitted if the external fallback provider was not allowed
   - ``true`` if the external fallback provider was allowed
+  - Omitted if the external fallback provider was not allowed
 
 .. versionchanged:: 2020.04.16
    Removed the ``region`` tag
 
 Related structured log data:
 
-* `api_key`_: same value as tag ``key``
-* `source_internal_accuracy`_: accuracy level of the internal source
-* `source_internal_accuracy_min`_: required accuracy level of the internal source,
-  same value as tag ``accuracy`` when ``source=internal``
-* `source_internal_status`_: same value as tag ``status`` when ``source=internal``
-* `source_geoip_accuracy`_: accuracy level of the GeoIP source
-* `source_geoip_accuracy_min`_: required accuracy level of the GeoIP source,
+* `api_key`_: The same value as tag ``key``
+* `source_internal_accuracy`_: The accuracy level of the internal source
+* `source_internal_accuracy_min`_: The required accuracy level of the internal
+  source, same value as tag ``accuracy`` when ``source=internal``
+* `source_internal_status`_: The same value as tag ``status`` when ``source=internal``
+* `source_geoip_accuracy`_: The accuracy level of the GeoIP source
+* `source_geoip_accuracy_min`_: The required accuracy level of the GeoIP source,
   same value as tag ``accuracy`` when ``source=geoip``
-* `source_geoip_status`_: same value as tag ``status`` when ``source=geoip``
-* `source_fallback_accuracy`_: accuracy level of the external fallback source
-* `source_fallback_accuracy_min`_: required accuracy level of the fallback source,
+* `source_geoip_status`_: The same value as tag ``status`` when ``source=geoip``
+* `source_fallback_accuracy`_: The accuracy level of the external fallback source
+* `source_fallback_accuracy_min`_: The required accuracy level of the fallback source,
   same value as tag ``accuracy`` when ``source=fallback``
-* `source_fallback_status`_: same value as tag ``status`` when ``source=fallback``
+* `source_fallback_status`_: The same value as tag ``status`` when ``source=fallback``
 
 region.query
 ^^^^^^^^^^^^
@@ -448,19 +449,19 @@ API Metrics
 If a request is an API call, additional data can be added to the log:
 
 * ``accuracy``: The accuracy of the result, ``high``, ``medium``, or ``low``.
-* ``accuracy_min``: Minimum required accuracy of the result for a hit, ``high``,
+* ``accuracy_min``: The minimum required accuracy of the result for a hit, ``high``,
   ``medium``, or ``low``.
 * ``api_key``: An API key that has an entry in the API key table, often a UUID,
   or ``none`` if omitted. Same as statsd tag ``key``, except that known but
-  disallowed API keys at the key value, rather than ``invalid``.
+  disallowed API keys are the key value, rather than ``invalid``.
 * ``api_key_allowed``: ``False`` if a known API key is not allowed to call the
   API, omitted otherwise.
 * ``api_key_db_fail``: ``True`` when a database error prevented checking the
   API key. Omitted when the check is successful.
 * ``api_path``: The normalized API path, like ``v1.geolocate`` and
-  ``v2.geosubmit``. Same as statsd tag ``path``.
-* ``api_response_sig``: A de-identified hash to identify repeated geolocate
-  requests getting the same response.
+  ``v2.geosubmit``. Same as statsd tag ``path`` when an API is called.
+* ``api_response_sig``: A hash to identify repeated geolocate requests getting
+  the same response without identifying the client.
 * ``api_type``: The API type, ``locate``, ``submit``, or ``region``.
 * ``blue``: The count of Bluetooth radios in the request.
 * ``blue_valid``: The count of valid Bluetooth radios in the request.
@@ -471,35 +472,36 @@ If a request is an API call, additional data can be added to the log:
 * ``has_geoip``: ``True`` if there is GeoIP data for the client IP, otherwise
   ``False``.
 * ``has_ip``: ``True`` if the client IP was available, otherwise ``False``.
-* ``invalid_api_key``: The invalid API key (not in API table), omitted if valid or empty.
+* ``invalid_api_key``: The invalid API key not found in API table, omitted if known or empty.
 * ``rate_allowed``: ``True`` if allowed, ``False`` if not allowed due to rate
   limit, or omitted if the API is not rate-limited.
-* ``rate_quota``: Daily rate limit, or omitted if API is not rate-limited.
-* ``rate_remaining``: Remaining API calls to hit limit, 0 if none remaining, or
+* ``rate_quota``: The daily rate limit, or omitted if API is not rate-limited.
+* ``rate_remaining``: The remaining API calls to hit limit, 0 if none remaining, or
   omitted if the API is not rate-limited.
-* ``region``: The ISO region code for the IP address, ``null`` if none
+* ``region``: The ISO region code for the IP address, ``null`` if none.
 * ``result_status``: ``hit`` if an accurate estimate could be made, ``miss`` if
-  it could not
-* ``source_fallback_accuracy`: accuracy level of the external fallback source,
-  ``high``, ``medium``, or ``low``
-* ``source_fallback_accuracy_min``: required accuracy level of the fallback source
+  it could not.
+* ``source_fallback_accuracy``: The accuracy level of the external fallback
+  source, ``high``, ``medium``, or ``low``.
+* ``source_fallback_accuracy_min``: The required accuracy level of the fallback source.
 * ``source_fallback_status``: ``hit`` if the fallback source provided an accurate
-  estimate, ``miss`` if it did not
-* ``source_internal_accuracy``: accuracy level of the internal source (Bluetooth,
-  WiFi, and cell data compared against the database), ``high``, ``medium``, or ``low``
-* ``source_internal_accuracy_min``: required accuracy level of the internal source
+  estimate, ``miss`` if it did not.
+* ``source_internal_accuracy``: The accuracy level of the internal source (Bluetooth,
+  WiFi, and cell data compared against the database), ``high``, ``medium``, or ``low``.
+* ``source_internal_accuracy_min``: The required accuracy level of the internal source.
 * ``source_internal_status``: ``hit`` if the internal check provided an accurate
-  estimate, ``miss`` if it did not
-* ``source_geoip_accuracy``: accuracy level of the GeoIP source, ``high``,
-  ``medium``, or ``low``
-* ``source_geoip_accuracy_min``: required accuracy level of the GeoIP source
+  estimate, ``miss`` if it did not.
+* ``source_geoip_accuracy``: The accuracy level of the GeoIP source, ``high``,
+  ``medium``, or ``low``.
+* ``source_geoip_accuracy_min``: The required accuracy level of the GeoIP source.
 * ``source_geoip_status``: ``hit`` if the GeoIP database provided an accurate
-  estimate, ``miss`` if it did not
-* ``wifi``: The count of WiFi radios in the request
-* ``wifi_valid``: The count of valid WiFi radios in the request
+  estimate, ``miss`` if it did not.
+* ``wifi``: The count of WiFi radios in the request.
+* ``wifi_valid``: The count of valid WiFi radios in the request.
 
 Some of this data is duplicated in metrics:
 
+* `api.limit`_
 * `locate.query`_
 * `locate.request`_
 * `locate.result`_
@@ -637,8 +639,9 @@ Tags:
   data.export.batch_. Unlike that metric, ``internal`` is not used.
 * ``status``: The status of the export, which varies by type of export:
 
-  - ``backup`` (S3): ``success`` or ``failure``
-  - ``tostage`` (Submission API): HTTP code, usually ``200`` for success, ``400`` for failure.
+  - ``backup``: ``success`` or ``failure`` storing the report to S3
+  - ``tostage``: HTTP code returned by the submission API, usually ``200`` for
+    success or ``400`` for failure.
 
 data.export.upload.timing
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -665,8 +668,8 @@ data.observation.upload
 ^^^^^^^^^^^^^^^^^^^^^^^
 ``data.observation.upload`` is a counter of the number of Bluetooth, cell or
 WiFi :term:`observations` entering the data processing pipeline, before
-normalization and blocked station processing have been applied. This count is
-taken after a batch of :term:`reports` are decomposed into observations.
+normalization and blocked station processing. This count is taken after a batch
+of :term:`reports` are decomposed into observations.
 
 The tags (``key`` and ``type``) are the same as `data.observation.drop`_.
 
@@ -712,8 +715,8 @@ data.station.blocklist
 :term:`stations` that are blocked from being used to estimate positions.
 These are added because there are multiple valid :term:`observations` at
 sufficiently different locations, supporting the theory that it is a
-mobile station (such as a picocell or mobile hotspot on a public transit
-vehicle), or was recently moved (a WiFi base station that moved with the
+mobile station (such as a picocell or a mobile hotspot on public transit),
+or was recently moved (such as a WiFi base station that moved with the
 owner to a new home).
 
 Tags:
@@ -742,9 +745,9 @@ Sentry.
 Tags:
 
 * ``errno``: The error number, which can be found in the 
-  `MySQL Server Error Reference`_.
+  `MySQL Server Error Reference`_
 * ``type``: The :term:`station`, one of ``blue``, ``cell``, or ``wifi``,
-  or the aggregate station type ``cellarea``.
+  or the aggregate station type ``cellarea``
 
 .. _`MySQL Server Error Reference`: https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html
 
@@ -806,7 +809,7 @@ are used to implement the data pipeline and monitoring tasks.
 Tags:
 
 * ``task``: The task name, such as ``data.export_reports`` or
-  ``data.update_statcounter``.
+  ``data.update_statcounter``
 
 Datamaps Metrics
 ================
@@ -843,8 +846,8 @@ Implementation
 Ichnaea emits statsd-compatible metrics using markus_, if the ``STATSD_HOST``
 is configured (see :ref:`the config section <config>`). Metrics use the the
 tags extension, which add queryable dimensions to the metrics. In development,
-the metrics are displayed with the logs. In production, metrics are stored in
-an InfluxDB_ database, and can be displayed as graphs with Grafana_.
+the metrics are displayed with the logs. In production, the metrics are stored
+in an InfluxDB_ database, and can be displayed as graphs with Grafana_.
 
 .. _markus: https://markus.readthedocs.io/en/latest/
 .. _InfluxDB: https://docs.influxdata.com/influxdb/v1.8/
@@ -871,7 +874,8 @@ Metric tag values are limited to avoid high cardinality issues. For example,
 rather than storing the number of WiFi stations, the ``wifi`` tag of the
 `locate.query`_ metric has the values ``none``, ``one``, and ``many``. The
 region, such as ``US`` or ``DE``, was once stored as a tag, but this can have
-almost 250 values.
+almost 250 values, causing MLS to have the highest processing load across
+Mozilla projects.
 
 BigQuery easily handles high-cardinality data, so structured logs can contain
 precise values, such as the actual number of WiFi stations provided, and more

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -12,46 +12,47 @@ Ichnaea provides two classes of runtime data:
 Structured logs were added in 2020, and the migration of data from metrics to
 logs is not complete. For more information, see the Implementation_ section.
 
-These are the metrics emitted by Ichnaea:
+Metrics are emitted by the web / API application, the async task application,
+and the datamaps script:
 
-================================ ======= =======================================================
-Metric Name                      Type    Tags
-================================ ======= =======================================================
-`api.limit`_                     gauge   key, path
-`data.batch.upload`_             counter key
-`data.export.batch`_             counter key
-`data.export.upload`_            counter key, status
-`data.export.upload.timing`_     timer   key
-`data.observation.drop`_         counter type, key
-`data.observation.insert`_       counter type
-`data.observation.upload`_       counter type, key
-`data.report.drop`_              counter key
-`data.report.upload`_            counter key
-`data.station.blocklist`_        counter type
-`data.station.confirm`_          counter type
-`data.station.dberror`_          counter type, errno
-`data.station.new`_              counter type
-`datamaps`_                      timer   func, count
-`datamaps.dberror`_              counter errno
-`locate.fallback.cache`_         counter fallback_name, status
-`locate.fallback.lookup`_        counter fallback_name, status
-`locate.fallback.lookup.timing`_ timer   fallback_name, status
-`locate.query`_                  counter key, geoip, blue, cell, wifi
-`locate.request`_                counter key, path
-`locate.result`_                 counter key, accuracy, status, source, fallback_allowed
-`locate.source`_                 counter key, accuracy, status, source
-`locate.user`_                   gauge   key, interval
-`queue`_                         gauge   queue
-`region.query`_                  counter key, geoip, blue, cell, wifi
-`region.request`_                counter key, path
-`region.result`_                 counter key, accuracy, status, source, fallback_allowed
-`region.user`_                   gauge   key, interval
-`request`_                       counter path, method, status
-`request.timing`_                timer   path, method
-`submit.request`_                counter key, path
-`submit.user`_                   gauge   key, interval
-`task`_                          timer   task
-================================ ======= =======================================================
+================================ ======== ======= =======================================================
+Metric Name                      App      Type    Tags
+================================ ======== ======= =======================================================
+`api.limit`_                     task     gauge   key, path
+`data.batch.upload`_             web      counter key
+`data.export.batch`_             task     counter key
+`data.export.upload`_            task     counter key, status
+`data.export.upload.timing`_     task     timer   key
+`data.observation.drop`_         task     counter type, key
+`data.observation.insert`_       task     counter type
+`data.observation.upload`_       task     counter type, key
+`data.report.drop`_              task     counter key
+`data.report.upload`_            task     counter key
+`data.station.blocklist`_        task     counter type
+`data.station.confirm`_          task     counter type
+`data.station.dberror`_          task     counter type, errno
+`data.station.new`_              task     counter type
+`datamaps`_                      datamaps timer   func, count
+`datamaps.dberror`_              datamaps counter errno
+`locate.fallback.cache`_         web      counter fallback_name, status
+`locate.fallback.lookup`_        web      counter fallback_name, status
+`locate.fallback.lookup.timing`_ web      timer   fallback_name, status
+`locate.query`_                  web      counter key, geoip, blue, cell, wifi
+`locate.request`_                web      counter key, path
+`locate.result`_                 web      counter key, accuracy, status, source, fallback_allowed
+`locate.source`_                 web      counter key, accuracy, status, source
+`locate.user`_                   task     gauge   key, interval
+`queue`_                         task     gauge   queue
+`region.query`_                  web      counter key, geoip, blue, cell, wifi
+`region.request`_                web      counter key, path
+`region.result`_                 web      counter key, accuracy, status, source, fallback_allowed
+`region.user`_                   task     gauge   key, interval
+`request`_                       web      counter path, method, status
+`request.timing`_                web      timer   path, method
+`submit.request`_                web      counter key, path
+`submit.user`_                   task     gauge   key, interval
+`task`_                          task     timer   task
+================================ ======== ======= =======================================================
 
 Web Application Metrics
 =======================

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,22 +1,18 @@
 .. _metrics:
 
-=======
-Metrics
-=======
+===========================
+Metrics and Structured Logs
+===========================
 
-.. Note:: 2019-09-24: This needs to be updated.
+Ichnaea provides two classes of runtime data:
 
-Ichnaea emits statsd-compatible metrics using markus_, if the ``STATSD_HOST``
-is configured (see :ref:`the config section <config>`).
+* Statsd-style **Metrics**, for real-time monitoring and easy visual analysis of trends
+* **Structured Logs**, for offline analysis of data and targeted custom reports
 
-.. _markus: https://markus.readthedocs.io/en/latest/
+Structured logs were added in 2020, and the migration of data from metrics to
+logs is not complete. For more information, see the Implementation_ section.
 
-Most metrics use the the statsd tags extension. A metric
-name of ``task#name:function,version:old`` means a statsd metric
-called ``task`` will be emitted with two tags ``name:function`` and
-``version:old``.
-
-Here's a summary of the metrics emitted by Ichnaea:
+These are the metrics emitted by Ichnaea:
 
 ================================ ======= =======================================================
 Metric Name                      Type    Tags
@@ -46,6 +42,7 @@ Metric Name                      Type    Tags
 `locate.source`_                 counter key, accuracy, status, source
 `locate.user`_                   gauge   key, interval
 `queue`_                         gauge   queue
+`region.query`_                  counter key, geoip, blue, cell, wifi
 `region.request`_                counter key, path
 `region.result`_                 counter key, accuracy, status, source, fallback_allowed
 `region.user`_                   gauge   key, interval
@@ -56,504 +53,834 @@ Metric Name                      Type    Tags
 `task`_                          timer   task
 ================================ ======= =======================================================
 
-.. _locate.request:
-.. _region.request:
-.. _submit.request:
-
-API Request Metrics
--------------------
-
-These are metrics that track how many times each specific public API
-is used and which clients identified by their API keys do so. They are
-grouped by the type of the API, where type is one of `locate`, `region`
-and `submit`, independent of the specific version of that API.
-
-These metrics can help in deciding when to remove a deprecated API.
-
-``locate.request#path:v1.search,key:<apikey>``,
-``locate.request#path:v1.geolocate,key:<apikey>``,
-``region.request#path:v1.country,key:<apikey>``,
-``submit.request#path:v1.submit,key:<apikey>``,
-``submit.request#path:v1.geosubmit,key:<apikey>``,
-``submit.request#path:v2.geosubmit,key:<apikey>`` : counters
-
-    These metrics count how many times a specific API was called by a
-    specific API key expressed via the API keys short name. The API key
-    is the actual API key, often a UUID.
-
-    Two special short names exist for tracking invalid (``invalid``)
-    and no (``none``) provided API keys.
-
-.. _locate.user:
-.. _region.user:
-.. _submit.user:
-
-API User Metrics
-----------------
-
-For all API requests including the submit-type APIs we gather metrics
-about the number of unique users based on the users IP addresses.
-
-These metrics are gathered under the metric prefix:
-
-``<api_type>.user#key<apikey>`` : gauge
-
-They have an additional tag to determine the time interval for which
-the unique users are aggregated for:
-
-``#interval:1d``, ``interval:7d`` : tags
-
-    Unique users per day or last 7 days.
-
-Technically these metrics are based on HyperLogLog cardinality numbers
-maintained in a Redis service. They should be accurate to about 1% of
-the actual number.
-
-.. _locate.query:
-
-API Query Metrics
------------------
-
-For each incoming API query we log metrics about the data contained in
-the query with the metric name and tag:
-
-``<api_type>.query#key<apikey>`` : counter
-
-`api_type` describes the type of API being used, independent of the
-version number of the API. So `v1/country` gets logged as `region`
-and both `v1/search` and `v1/geolocate` get logged as `locate`.
-
-We extend the metric with additional tags based on the data contained
-in it:
-
-``#geoip:false`` : tag
-
-    This tag only gets added if there was no valid client IP address
-    for this query. Since almost all queries contain a client IP address
-    we usually skip this tag.
-
-``#blue:none``, ``#blue:one``, ``#blue:many``,
-``#cell:none``, ``#cell:one``, ``#cell:many``,
-``#wifi:none``, ``#wifi:one``, ``#wifi:many`` : tags
-
-    If the query contained any Bluetooth, cell or WiFi networks,
-    one blue, cell and wifi tag get added. The tags depend on the
-    number of valid :term:`stations` for each of the three.
-
-.. versionchanged:: 2020.04.16
-   Removed the ``region`` tag
-
-.. _locate.result:
-.. _region.result:
-
-API Result Metrics
-------------------
-
-Similar to the API query metrics we also collect metrics about each
-result of an API query. This follows the same per API type and per
-region rules under the prefix / tag combination:
-
-``<api_type>.result#key:<apikey>``
-
-The result metrics measure if we satisfied the incoming API query in
-the best possible fashion. Incoming queries can generally contain
-an IP address, Bluetooth, cell, WiFi networks or any combination thereof.
-If the query contained only cell networks, we do not expect to get a
-high accuracy result, as there is too little data in the query to do so.
-
-We express this by classifying each incoming query into one of four
-categories:
-
-High Accuracy (``#accuracy:high``)
-    A query containing at least two Bluetooth or WiFi networks.
-
-Medium Accuracy (``#accuracy:medium``)
-    A query containing neither Bluetooth nor WiFi networks but at
-    least one cell network.
-
-Low Accuracy (``#accuracy:low``)
-    A query containing no networks but only the IP address of the client.
-
-No Accuracy (``#accuracy:none``)
-    A query containing no usable information, for example an IP-only
-    query that explicitly disables the IP fallback.
-
-A query containing multiple data types gets put into the best possible
-category, so for example any query containing cell data will at least
-be of medium accuracy.
-
-One we have determined the expected accuracy category for the query, we
-compare it to the accuracy category of the result we determined. If we
-can deliver an equal or better category we consider the status to be
-a `hit`. If we don't satisfy the expected category we consider the
-result to be a `miss`.
-
-For each result we then log exactly one of the following tag combinations:
-
-``#accuracy:high,status:hit``, ``#accuracy:high,status:miss``,
-``#accuracy:medium,status:hit``, ``#accuracy:medium,status:miss``,
-``#accuracy:low,status:hit``, ``#accuracy:low,status:miss`` : tags
-
-We don't log metrics for the uncommon case of ``none`` or no expected
-accuracy.
-
-One special case exists for cell networks. If we cannot find an exact
-cell match, we might fall back to a cell area based estimate. If the
-range of the cell area is fairly small we consider this to be a
-``#accuracy:medium,status:hit``. But if the size of the cell area is
-extremely large, in the order of tens of kilometers to hundreds of
-kilometers, we consider it to be a ``#accuracy:medium,status:miss``.
-
-In the past we only collected stats based on whether or not cell based
-data was used to answer a cell based query and counted it as a
-cell-based success, even if the provided accuracy was really bad.
-
-In addition to the accuracy of the result, we also tag the result
-metric with the data source that got used to provide the result,
-but only for results that met the expected accuracy.
-
-``#source:<source_name>`` : tag
-
-Data sources can be one of:
-
-``internal``
-    Data from our own crowd-sourcing effort.
-
-``fallback``
-    Data from the optional external fallback provider.
-
-``geoip``
-    Data from a GeoIP database.
-
-And finally we add a tag to state whether or not the query was allowed
-to use the fallback source.
-
-``#fallback_allowed:<value>`` : tag
-
-    The value is either `true` or `false`.
-
-.. versionchanged:: 2020.04.16
-   Removed the ``region`` tag
-
-.. _locate.source:
-
-API Source Metrics
-------------------
-
-In addition to the final API result, we also collect metrics about each
-individual data source we use to answer queries under the
-``<api_type>.source#key:<apikey>`` metric.
-
-Each request may use one or multiple of these sources to deliver a result.
-We log the same metrics as mentioned above for the result.
-
-All of this combined might lead to a tagged metric like:
-
-``locate.source#key:test,source:geoip,accuracy:low,status:hit``
-
-.. versionchanged:: 2020.04.16
-   Removed the ``region`` tag
-
-.. _locate.fallback.cache:
-.. _locate.fallback.lookup:
-.. _locate.fallback.lookup.timing:
-
-API Fallback Source Metrics
----------------------------
-
-The external fallback source has a couple extra metrics to observe the
-performance of outbound network calls and the effectiveness of its cache.
-
-The fallback name tag specifies which fallback service is used.
-
-``locate.fallback.cache#fallback_name:<fallback_name>,status:hit``,
-``locate.fallback.cache#fallback_name:<fallback_name>,status:miss``,
-``locate.fallback.cache#fallback_name:<fallback_name>,status:bypassed``,
-``locate.fallback.cache#fallback_name:<fallback_name>,status:inconsistent``,
-``locate.fallback.cache#fallback_name:<fallback_name>,status:failure`` : counter
-
-    Counts the number of hits and misses for the fallback cache. If
-    the query should not be cached, a `bypassed` status is used.
-    If the cached values couldn't be read, a `failure` status is used.
-    If the cached values didn't agree on a consistent position,
-    a `inconsistent` status is used.
-
-``locate.fallback.lookup.timing#fallback_name:<fallback_name>`` : timer
-
-    Measures the time it takes to do each outbound network request.
-
-``locate.fallback.lookup#fallback_name:<fallback_name>,status:<code>`` : counter
-
-    Counts the HTTP response codes for all outbound requests. There
-    is one counter per HTTP response code, for example `200`.
-
-.. _data.batch.upload:
-.. _data.report.upload:
-.. _data.report.drop:
-.. _data.observation.upload:
-.. _data.observation.drop:
-.. _data.observation.insert:
-.. _data.station.confirm:
-.. _data.station.blocklist:
-.. _data.station.new:
-.. _data.station.dberror:
-
-Data Pipeline Metrics
----------------------
-
-When a batch of reports is accepted at one of the submission API
-endpoints, it is decomposed into a number of "items" -- wifi or cell
-:term:`observations` -- each of which then works its way through a process of
-normalization, consistency-checking and eventually (possibly) integration
-into aggregate :term:`station` estimates held in the main database tables.
-Along the way several counters measure the steps involved:
-
-``data.batch.upload``,
-``data.batch.upload#key:<apikey>`` : counters
-
-    Counts the number of "batches" of :term:`reports` accepted to the data
-    processing pipeline by an API endpoint. A batch generally
-    corresponds to the set of :term:`reports` uploaded in a single HTTP POST
-    to one of the submit APIs. In other words this metric counts
-    "submissions that make it past coarse-grained checks" such as API-key
-    and JSON schema validity checking.
-
-    The metric is either emitted per tracked API key, or for everything
-    else without a key tag.
-
-``data.report.upload``,
-``data.report.upload#key:<apikey>`` : counters
-
-    Counts the number of :term:`reports` accepted into the data processing
-    pipeline. The metric is either emitted per tracked API key, or for
-    everything else without a key tag.
-
-``data.report.drop``,
-``data.report.drop#key:<apikey>`` : counter
-
-    Count incoming :term:`reports` that were discarded due to some internal
-    consistency, range or validity-condition error.
-
-``data.observation.upload#type:blue``,
-``data.observation.upload#type:blue,key:<apikey>``,
-``data.observation.upload#type:cell``,
-``data.observation.upload#type:cell,key:<apikey>``,
-``data.observation.upload#type:wifi``,
-``data.observation.upload#type:wifi,key:<apikey>`` : counters
-
-    Count the number of Bluetooth, cell or WiFi :term:`observations` entering
-    the data processing pipeline; before normalization and blocklist processing
-    have been applied. In other words this metric counts "total Bluetooth,
-    cell or WiFi :term:`observations` inside each submitted batch", as each
-    batch is composed of individual :term:`observations`.
-
-    The metrics are either emitted per tracked API key, or for everything
-    else without a key tag.
-
-``data.observation.drop#type:blue``,
-``data.observation.drop#type:blue,key:<apikey>``,
-``data.observation.drop#type:cell``,
-``data.observation.drop#type:cell,key:<apikey>``,
-``data.observation.drop#type:wifi``
-``data.observation.drop#type:wifi,key:<apikey>`` : counters
-
-    Count incoming Bluetooth, cell or WiFi :term:`observations` that were
-    discarded before integration due to some internal consistency, range or
-    validity-condition error encountered while attempting to normalize the
-    :term:`observation`.
-
-``data.observation.insert#type:blue``,
-``data.observation.insert#type:cell``,
-``data.observation.insert#type:wifi`` : counters
-
-    Count Bluetooth, cell or WiFi :term:`observations` that are successfully
-    normalized, integrated and not discarded due to consistency errors.
-
-``data.station.blocklist#type:blue``,
-``data.station.blocklist#type:cell``,
-``data.station.blocklist#type:wifi`` : counters
-
-    Count any Bluetooth, cell or WiFi network that is blocklisted due to
-    the acceptance of multiple :term:`observations` at sufficiently different
-    locations. In these cases, we decide that the :term:`station` is "moving"
-    (such as a picocell or mobile hotspot on a public transit vehicle) and
-    blocklist it, to avoid estimating query positions using the
-    :term:`station`.
-
-``data.station.confirm#type:blue``,
-``data.station.confirm#type:cell``,
-``data.station.confirm#type:wifi`` : counters
-
-    Count the number of Bluetooth, cell or WiFi :term:`station` that were
-    successfully confirmed by any type of :term:`observations`.
-
-``data.station.new#type:blue``,
-``data.station.new#type:cell``,
-``data.station.new#type:wifi`` : counters
-
-    Count the number of Bluetooth, cell or WiFi :term:`station` that were
-    discovered for the first time.
-
-``data.station.dberror#type:<type>,errno:<errno>``: counters
-
-    Count the number of retryable database errors.  ``type`` is ``blue``,
-    ``cell``, ``cellarea``, or ``wifi``, and ``errno`` is the error number,
-    which can be found on the `MySQL Server Error Reference`_.
-
-    Retryable database errors, like a lock timeout (``1205``) or deadlock
-    (``1213``) cause the station updating task to sleep and start over.  Other
-    database errors are not counted, but instead halt the task and are recorded
-    in Sentry.
-
-.. _data.export.batch:
-.. _data.export.upload:
-.. _data.export.upload.timing:
-
-Data Pipeline Export Metrics
-----------------------------
-
-Incoming :term:`reports` can also be sent to a number of different export
-targets. We keep metrics about how those individual export targets perform.
-
-``data.export.batch#key:<export_key>`` : counter
-
-    Count the number of batches sent to the export target.
-
-``data.export.upload.timing#key:<export_key>`` : timer
-
-    Track how long the upload operation took per export target.
-
-``data.export.upload#key:<export_key>,status:<status>`` : counter
-
-    Track the upload status of the current job. One counter per status.
-    A status can either be a simple `success` and `failure` or a HTTP
-    response code like 200, 400, etc.
-
-.. _api.limit:
-.. _queue:
-
-Internal Monitoring
--------------------
-
-``api.limit#key:<apikey>,#path:<path>`` : gauge
-
-    One gauge is created per API key and API path which has rate limiting
-    enabled on it. This gauge measures how many requests have been done
-    for each such API key and path combination for the current day.
-
-``queue#queue:celery_blue``,
-``queue#queue:celery_cell``,
-``queue#queue:celery_default``,
-``queue#queue:celery_export``,
-``queue#queue:celery_incoming``,
-``queue#queue:celery_monitor``,
-``queue#queue:celery_reports``,
-``queue#queue:celery_wifi`` : gauges
-
-    These gauges measure the number of tasks in each of the Redis queues.
-    They are sampled at an approximate per-minute interval.
-
-``queue#queue:update_blue_0``,
-``queue#queue:update_blue_f``,
-``queue#queue:update_cell_gsm``,
-``queue#queue:update_cell_wcdma``,
-``queue#queue:update_cell_lte``,
-``queue#queue:update_cellarea``,
-``queue#queue:update_datamap_ne``,
-``queue#queue:update_datamap_nw``,
-``queue#queue:update_datamap_se``,
-``queue#queue:update_datamap_sw``,
-``queue#queue:update_wifi_0``,
-``queue#queue:update_wifi_f`` : gauges
-
-    These gauges measure the number of items in the Redis update queues.
-
-.. _request:
-
-HTTP Counters
--------------
-
-Every legitimate, routed request to an API endpoint or to a content
-view increments a ``request#path:<path>,method:<method>,status:<code>``
-counter.
-
-The path of the counter is the based on the path of the HTTP
-request, with slashes replaced with periods. The method tag contains
-the lowercased HTTP method of the request. The status tag contains
-the response code produced by the request.
-
-For example, a GET of ``/stats/regions`` that results in an HTTP 200
-status code, will increment the counter
-``request#path:stats.regions,method:get,status:200``.
-
-Response codes in the 400 range (eg. 404) are only generated for HTTP
-paths referring to API endpoints. Logging them for unknown and invalid
-paths would overwhelm the system with all the random paths the friendly
-Internet bot army sends along.
-
-.. _request.timing:
-
-HTTP Timers
------------
-
-In addition to the HTTP counters, every legitimate, routed request
-emits a ``request.timing#path:<path>,method:<method>`` timer.
-
-These timers have the same structure as the HTTP counters, except they
-do not have the response code tag.
-
-.. _task:
-
-Task Timers
------------
-
-Our data ingress and data maintenance actions are managed by a Celery
-queue of tasks. These tasks are executed asynchronously, and each task
-emits a timer indicating its execution time.
-
-For example:
-
-  - ``task#task:data.export_reports``
-  - ``task#task:data.update_statcounter``
-
-.. _datamaps:
-.. _datamaps.dberror:
-
-Datamaps Timers
+Web Application Metrics
+=======================
+The website handles HTTP requests, which may be page requests or API calls.
+
+Request Metrics
 ---------------
+Each HTTP request, including API calls, emits metrics and a structured log entry.
 
-We include a script to generate a data map from the gathered map
-statistics. This script includes a number of timers and pseudo-timers
-to monitor its operation.
+request
+^^^^^^^
+``request`` is a counter for almost all HTTP requests, including API calls. The
+exceptions are static assets, like CSS, images, Javascript, and fonts, as well as
+some static content like ``robots.txt``.
 
-``datamaps#func:export``,
-``datamaps#func:encode``,
-``datamaps#func:merge``,
-``datamaps#func:main``,
-``datamaps#func:render``,
-``datamaps#func:upload`` : timers
+Additionally, invalid requests (HTTP status in the ``4xx`` range) do not omit this
+metric, unless they are API endpoints.
 
-    These timers track the individual functions of the generation process.
+The request path, like ``/stats/regions``, is normalized to tag-safe characters
+and included as the ``path`` tag. The initial slash is dropped, and remaining
+slashes are replaced with periods, so ``/stats/regions`` becomes ``stats.regions``.
+The homepage, ``/`` is normalized as ``.homepage``, to avoid an empty tag value.
 
-``datamaps#count:csv_rows``,
-``datamaps#count:quadtrees``,
-``datamaps#count:tile_new``,
-``datamaps#count:tile_changed``,
-``datamaps#count:tile_deleted``,
-``datamaps#count:tile_unchanged`` : timers
+Tags:
 
-    Pseudo-timers to track the number of CSV rows, Quadtree files and
-    image tiles.
+* ``path``: The metrics-normalized HTTP path, like ``stats.regions``,
+  ``v1.geolocate``, and ``.homepage``
+* ``method``: The HTTP method in lowercase, like ``post``, ``get``, ``head``,
+  and ``options``
+* ``status``: The returned HTTP status, like ``200`` for success and ``400``
+  for client errors
 
+Related structured log data:
 
-``datamaps.dberror#errno:<errno>``: counter
+* `http_method`_: The non-normalized HTTP method
+* `http_path`_: The non-normalized request path
+* `http_status`_: The HTTP status code
 
-    Count the number of retryable database errors.  ``errno`` is the error
-    number, which can be found on the `MySQL Server Error Reference`_.
+request.timing
+^^^^^^^^^^^^^^
+``request.timing`` is a timer for how long the HTTP request took to complete in
+milliseconds.
 
-    Retryable database errors, like a lock timeout (``1205``) or deadlock
-    (``1213``) cause the station updating task to sleep and start over.  Other
-    database errors are not counted, but instead halt the task and are recorded
-    in Sentry.
+The tags (``path``, ``method``, and ``status``) are the same as `request`_.
+
+Related structured log data:
+
+* `duration_s`_: The time the request took in seconds, rounded to the millisecond
+
+API Metrics
+-----------
+These metrics are emitted when the API is called.
+
+data.batch.upload
+^^^^^^^^^^^^^^^^^
+``data.batch.upload`` is a counter that is incremented when a submit API, like
+:ref:`/v2/geosubmit <api_geosubmit2>`, is called with any valid data. A
+submission batch could contain a single report or multiple reports, but both
+would increment ``data.batch.upload`` by one. A batch with no (valid) reports
+does not increment this metric.
+
+Tags:
+
+* ``key``: The API key, often a UUID, or omitted if the API key is not valid.
+
+Related structured log data:
+
+* `api_key`_: same value as tag ``key`` for valid keys
+
+locate.query
+^^^^^^^^^^^^
+``locate.query`` is a counter, incremented each time the
+:ref:`Geolocate API <api_geolocate_latest>` is used with a valid API key that
+is not rate limited. It is used to segment queries by the station data
+contained in the request body.
+
+Tags:
+
+* ``key``: The API key, often a UUID
+* ``geoip``: omitted when there is GeoIP data for the client IP (common case),
+  ``false`` if there was no GeoIP data
+* ``blue``: Count of valid Bluetooth :term:`stations` in the request, ``none``, ``one``
+  or ``many``
+* ``cell``: Count of valid cell :term:`stations` in the request, ``none``, ``one``, or
+  ``many``
+* ``wifi``: Count of valid WiFi :term:`stations` in the request, ``none``, ``one``, or
+  ``many``
+
+.. versionchanged:: 2020.04.16
+   Removed the ``region`` tag
+
+Related structured log data:
+
+* `api_key`_: same value as tag ``key``
+* `has_geoip`_: Always set, ``False`` when ``geoip`` is ``false``
+* `blue`_: Count of Bluetooth stations, as a number instead of text like ``many``
+* `cell`_: Count of Cell stations
+* `wifi`_: Count of WiFi stations
+
+locate.request
+^^^^^^^^^^^^^^
+``locate.request`` is a counter, incremented for each call to the
+:ref:`Geolocate API <api_geolocate_latest>`.
+
+Tags:
+
+* ``key``: The API key, often a UUID, or ``invalid`` for a known key that can
+  not call the API, or ``none`` for an omitted key.
+* ``path``: ``v1.geolocate``, the standardized API path
+
+Related structured log data:
+
+* `api_key`_: same value as tag ``key``, except that instead of ``invalid``,
+  the request key is used, and ``api_key_allowed=False``
+* `api_key_allowed`_: ``False`` when the key is not allowed to use the API
+* `api_path`_: same value as tag ``path``
+* `api_type`_: value set to ``locate``
+
+locate.result
+^^^^^^^^^^^^^
+``locate.result`` is a counter, incremented for each call to the
+:ref:`Geolocate API <api_geolocate_latest>` with a valid API key that is not
+rate limited.
+
+If there are no Bluetooth, Cell, or WiFi networks provided, and GeoIP data is
+not available (for example, the IP fallback is explicitly disabled), then this
+metric is not emitted.
+
+Tags:
+
+* ``key``: The API key, often a UUID
+* ``accuracy``: The expected accuracy, based on the sources provided:
+
+  - ``high``: At least two Bluetooth or WiFi networks
+  - ``medium``: No Bluetooth or WiFi networks, at least one cell network
+  - ``low``: No networks, only GeoIP data
+
+* ``status``: Could we provide a location estimate?
+
+  - ``hit`` if we can provide a location with the expected accuracy,
+  - ``miss`` if we can not provide a location with the expected accuracy.
+    For cell networks (``accuracy=medium``), a ``hit`` includes the case
+    where there is not an exact cell match, but the cell area (the area
+    covered by related cells) is small enough (smaller than tens of
+    kilometers across) for an estimate.
+
+* ``source``: The source that provided the hit:
+
+  - omitted when ``status=miss``
+  - ``internal``: Our crowd-sourced network data
+  - ``geoip``: The MaxMind GeoIP database
+  - ``fallback``: An optional external fallback provider
+
+* ``fallback_allowed``:
+
+  - omitted if the external fallback provider was not allowed
+  - ``true`` if the external fallback provider was allowed
+
+.. versionchanged:: 2020.04.16
+   Removed the ``region`` tag
+
+Related structured log data:
+
+* :ref:`accuracy <accuracy_metric>`: accuracy level of the result, ``high``,
+  ``medium``, or ``low``
+* `accuracy_min`_: same value as tag ``accuracy``
+* `api_key`_: same value as tag ``key``
+* `result_status`_: same value as tag ``status``
+
+locate.source
+^^^^^^^^^^^^^
+``locate.source`` is a counter, incremented for each processed source in
+a location query. If :term:`station` data (Bluetooth, WiFi, and Cell data)
+is provided, this usually two metrics for one request, one for the
+``internal`` source and one for the ``geoip`` source.
+
+The required accuracy for a ``hit`` is set by the kind of station data in the
+request. For example, a request with no station data requires a ``low``
+accuracy, while one with multiple WiFi networks requires a ``high`` accuracy.
+The ``high`` accuracy is at least 500 meters, and the minimum current MaxMind
+accuracy is 1000 meters, so the ``geoip`` source is expected to have a ``miss``
+status when accuracy is ``high``.
+
+Tags (similar to `locate.result`_) :
+
+* ``key``: The API key, often a UUID
+* ``accuracy``: The expected accuracy, based on the sources provided:
+
+  - ``high``: At least two Bluetooth or WiFi networks
+  - ``medium``: No Bluetooth or WiFi networks, at least one cell network
+  - ``low``: No networks, only GeoIP data
+
+* ``status``: Could we provide a location estimate?
+
+  - ``hit`` if we can provide a location with the expected accuracy,
+  - ``miss`` if we can not provide a location with the expected accuracy
+
+* ``source``: The source that was processed:
+
+  - ``internal``: Our crowd-sourced network data
+  - ``geoip``: The MaxMind GeoIP database
+  - ``fallback``: An optional external fallback provider
+
+* ``fallback_allowed``:
+
+  - omitted if the external fallback provider was not allowed
+  - ``true`` if the external fallback provider was allowed
+
+.. versionchanged:: 2020.04.16
+   Removed the ``region`` tag
+
+Related structured log data:
+
+* `api_key`_: same value as tag ``key``
+* `source_internal_accuracy`_: accuracy level of the internal source
+* `source_internal_accuracy_min`_: required accuracy level of the internal source,
+  same value as tag ``accuracy`` when ``source=internal``
+* `source_internal_status`_: same value as tag ``status`` when ``source=internal``
+* `source_geoip_accuracy`_: accuracy level of the GeoIP source
+* `source_geoip_accuracy_min`_: required accuracy level of the GeoIP source,
+  same value as tag ``accuracy`` when ``source=geoip``
+* `source_geoip_status`_: same value as tag ``status`` when ``source=geoip``
+* `source_fallback_accuracy`_: accuracy level of the external fallback source
+* `source_fallback_accuracy_min`_: required accuracy level of the fallback source,
+  same value as tag ``accuracy`` when ``source=fallback``
+* `source_fallback_status`_: same value as tag ``status`` when ``source=fallback``
+
+region.query
+^^^^^^^^^^^^
+``region.query`` is a counter, incremented each time the
+:ref:`Region API <api_region_latest>` is used with a valid API key. It is used
+to segment queries by the station data contained in the request body.
+
+It has the same tags (``key``, ``geoip``, ``blue``, ``cell``, and ``wifi``) as
+`locate.query`_.
+
+region.request
+^^^^^^^^^^^^^^
+``region.request`` is a counter, incremented for each call to the
+:ref:`Region API <api_region_latest>`.
+
+It has the same tags (``key`` and ``path``) as `locate.request`_, except the
+``path`` tag is ``v1.country``, the standardized API path.
+
+region.result
+^^^^^^^^^^^^^
+``region.result`` is a counter, incremented for each call to the
+:ref:`Region API <api_region_latest>` with a valid API key that is not
+rate limited.
+
+If there are no Bluetooth, Cell, or WiFi networks provided, and GeoIP data is
+not available (for example, the IP fallback is explicitly disabled), then this
+metric is not emitted.
+
+It has the same tags (``key``, ``accuracy``, ``status``, ``source``, and
+``fallback_allowed``) as `locate.result`_.
+
+region.source
+^^^^^^^^^^^^^
+``region.source`` is a counter, incremented for each processed source in
+a region query. If :term:`station` data (Bluetooth, WiFi, and Cell data)
+is provided, this usually two metrics for one request, one for the
+``internal`` source and one for the ``geoip`` source. In practice, most
+users provide no station data, and only the ``geoip`` source is emitted.
+
+It has the same tags (``key``, ``accuracy``, ``status``, ``source``, and
+``fallback_allowed``) as `locate.source`_.
+
+submit.request
+^^^^^^^^^^^^^^
+``submit.request`` is a counter, incremented for each call to a Submit API:
+
+* :ref:`api_geosubmit_latest`
+* :ref:`api_submit`
+* :ref:`api_geosubmit`
+
+This counter can be used to determine when the deprecated APIs can be removed.
+
+It has the same tags (``key`` and ``path``) as `locate.request`_, except the
+``path`` tag is ``v2.geosubmit``, ``v1.submit``, or ``v1.geosubmit``, the
+standardized API path.
+
+API Fallback Metrics
+--------------------
+These metrics were emitted when the fallback location provider was called.  MLS
+stopped using this feature in 2019, so these metrics are not emitted, but the
+code remains as of 2020.
+
+These metrics have not been converted to structured logs.
+
+locate.fallback.cache
+^^^^^^^^^^^^^^^^^^^^^
+``locate.fallback.cache`` is a counter for the performance of the fallback cache.
+
+Tags:
+
+* ``fallback_name``: The name of the external fallback provider, from the API
+  key table
+* ``status``: The status of the fallback cache:
+
+  - ``hit``: The cache had a previous result for the query
+  - ``miss``: The cache did not have a previous result for the query
+  - ``bypassed``: The cache was not used, due to mixed :term:`stations` in
+    the query, or the high number of individual stations
+  - ``inconsistent``: The cached results were for multiple inconsistent
+    locations
+  - ``failure``: The cache was unreachable
+
+locate.fallback.lookup
+^^^^^^^^^^^^^^^^^^^^^^
+``locate.fallback.lookup`` is a counter for the HTTP response codes returned
+from the fallback server.
+
+Tags:
+
+* ``fallback_name``: The name of the external fallback provider, from the API
+  key table
+* ``status``: The HTTP status code, such as ``200``
+
+locate.fallback.lookup.timing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``locate.fallback.lookup.timing`` is a timer for the call to the fallback
+location server.
+
+Tags:
+
+* ``fallback_name``: The name of the external fallback provider, from the API
+  key table
+* ``status``: The HTTP status code, such as ``200``
+
+Web Application Structured Logs
+===============================
+There is one structured log emitted for each request, which may be an API
+request. The structured log data includes data that was emitted as one or more
+metrics.
+
+.. _duration_s:
+.. _http_method:
+.. _http_path:
+.. _http_status:
+
+Request Metrics
+---------------
+All requests, with the exception of static assets and static views (see `request`_),
+include this data:
+
+* ``duration_s``: The time in seconds, rounded to the millisecond, to serve the request.
+* ``http_method``: The HTTP method, like ``POST`` or ``GET``.
+* ``http_path``: The request path, like ``/`` for the homepage, or
+  ``/v1/geolocate`` for the API.
+* ``http_status``: The response status, like ``200`` or ``400``.
+
+This data is duplicated in metrics:
+
+* `request`_
+* `request.timing`_
+
+.. _accuracy_metric:
+.. _accuracy_min:
+.. _api_key:
+.. _api_key_allowed:
+.. _api_key_db_fail:
+.. _api_path:
+.. _api_response_sig:
+.. _api_type:
+.. _blue:
+.. _blue_valid:
+.. _cell:
+.. _cell_valid:
+.. _fallback_allowed:
+.. _has_geoip:
+.. _has_ip:
+.. _invalid_api_key:
+.. _rate_allowed:
+.. _rate_quota:
+.. _rate_remaining:
+.. _region:
+.. _result_status:
+.. _source_fallback_accuracy:
+.. _source_fallback_accuracy_min:
+.. _source_fallback_status:
+.. _source_geoip_accuracy:
+.. _source_geoip_accuracy_min:
+.. _source_geoip_status:
+.. _source_internal_accuracy:
+.. _source_internal_accuracy_min:
+.. _source_internal_status:
+.. _wifi:
+.. _wifi_valid:
+
+API Metrics
+-----------
+If a request is an API call, additional data can be added to the log:
+
+* ``accuracy``: The accuracy of the result, ``high``, ``medium``, or ``low``.
+* ``accuracy_min``: Minimum required accuracy of the result for a hit, ``high``,
+  ``medium``, or ``low``.
+* ``api_key``: An API key that has an entry in the API key table, often a UUID,
+  or ``none`` if omitted. Same as statsd tag ``key``, except that known but
+  disallowed API keys at the key value, rather than ``invalid``.
+* ``api_key_allowed``: ``False`` if a known API key is not allowed to call the
+  API, omitted otherwise.
+* ``api_key_db_fail``: ``True`` when a database error prevented checking the
+  API key. Omitted when the check is successful.
+* ``api_path``: The normalized API path, like ``v1.geolocate`` and
+  ``v2.geosubmit``. Same as statsd tag ``path``.
+* ``api_response_sig``: A de-identified hash to identify repeated geolocate
+  requests getting the same response.
+* ``api_type``: The API type, ``locate``, ``submit``, or ``region``.
+* ``blue``: The count of Bluetooth radios in the request.
+* ``blue_valid``: The count of valid Bluetooth radios in the request.
+* ``cell``: The count of cell tower radios in the request.
+* ``cell_valid``: The count of valid cell tower radios in the request.
+* ``fallback_allowed``: ``True`` if the optional fallback location provider can
+  be used by this API key, ``False`` if not.
+* ``has_geoip``: ``True`` if there is GeoIP data for the client IP, otherwise
+  ``False``.
+* ``has_ip``: ``True`` if the client IP was available, otherwise ``False``.
+* ``invalid_api_key``: The invalid API key (not in API table), omitted if valid or empty.
+* ``rate_allowed``: ``True`` if allowed, ``False`` if not allowed due to rate
+  limit, or omitted if the API is not rate-limited.
+* ``rate_quota``: Daily rate limit, or omitted if API is not rate-limited.
+* ``rate_remaining``: Remaining API calls to hit limit, 0 if none remaining, or
+  omitted if the API is not rate-limited.
+* ``region``: The ISO region code for the IP address, ``null`` if none
+* ``result_status``: ``hit`` if an accurate estimate could be made, ``miss`` if
+  it could not
+* ``source_fallback_accuracy`: accuracy level of the external fallback source,
+  ``high``, ``medium``, or ``low``
+* ``source_fallback_accuracy_min``: required accuracy level of the fallback source
+* ``source_fallback_status``: ``hit`` if the fallback source provided an accurate
+  estimate, ``miss`` if it did not
+* ``source_internal_accuracy``: accuracy level of the internal source (Bluetooth,
+  WiFi, and cell data compared against the database), ``high``, ``medium``, or ``low``
+* ``source_internal_accuracy_min``: required accuracy level of the internal source
+* ``source_internal_status``: ``hit`` if the internal check provided an accurate
+  estimate, ``miss`` if it did not
+* ``source_geoip_accuracy``: accuracy level of the GeoIP source, ``high``,
+  ``medium``, or ``low``
+* ``source_geoip_accuracy_min``: required accuracy level of the GeoIP source
+* ``source_geoip_status``: ``hit`` if the GeoIP database provided an accurate
+  estimate, ``miss`` if it did not
+* ``wifi``: The count of WiFi radios in the request
+* ``wifi_valid``: The count of valid WiFi radios in the request
+
+Some of this data is duplicated in metrics:
+
+* `locate.query`_
+* `locate.request`_
+* `locate.result`_
+* `locate.source`_
+* `region.query`_
+* `region.request`_
+* `region.result`_
+* `region.source`_
+* `submit.request`_
+
+Task Application Metrics
+========================
+The task application, running on celery in the backend, implements the data
+pipeline and other periodic tasks. These emit metrics, but have not been
+converted to structured logging.
+
+API Monitoring Metrics
+----------------------
+These metrics are emitted periodically to monitor API usage. A Redis key is
+incremented or updated during API requests, and the current value is reported
+via these metrics:
+
+api.limit
+^^^^^^^^^
+``api.limit`` is a gauge of the API requests, segmented by API key and API
+path, for keys with daily limits. It is updated every 10 minutes.
+
+Tags:
+
+* ``key``: The API key, often a UUID
+* ``path``: The normalized API path, such as ``v1.geolocate`` or ``v2.geosubmit``
+
+Related structured log data is added during the request when an API key has
+rate limits:
+
+* `rate_allowed`_: ``True`` if the request was allowed, ``False`` if not allowed
+  due to the rate limit
+* `rate_quota`_: The daily rate limit
+* `rate_remaining`_: The remaining API calls to hit limit, 0 if none remaining
+
+locate.user
+^^^^^^^^^^^
+``locate.user`` is a gauge of the estimated number of daily and weekly users of
+the :ref:`Geolocate API <api_geolocate_latest>` by API key. It is updated
+every 10 minutes.
+
+The estimate is based on the client's IP address. At request time, the IP is
+added via PFADD_ to a HyperLogLog structure. This structure can be used to
+estimate the cardinality (number of unique IP addresses) to within about 1%.
+See PFCOUNT_ for details on the HyperLogLog implementation.
+
+.. _PFADD: https://redis.io/commands/pfadd
+.. _PFCOUNT: https://redis.io/commands/pfcount
+
+Tags:
+
+* ``key``: The API key, often a UUID
+* ``interval``: ``1d`` for the daily estimate, ``7d`` for the weekly estimate.
+
+region.user
+^^^^^^^^^^^
+``region.user`` is a gauge of the estimated number of daily and weekly users of
+the :ref:`Region API <api_region_latest>` by API key. It is updated every 10
+minutes.
+
+It has the same tags (``key`` and ``interval``) as `locate.user`_.
+
+submit.user
+^^^^^^^^^^^
+``submit.user`` is a gauge of the estimated number of daily and weekly users of
+the submit APIs (:ref:`/v2/geosubmit <api_geosubmit2>` and the
+deprecated submit APIs) by API key. It is updated every 10 minutes.
+
+It has the same tags (``key`` and ``interval``) as `locate.user`_.
+
+Data Pipeline Metrics - Gather and Export
+-----------------------------------------
+The data pipeline processes data from two sources:
+
+* **Submission reports**, from the submission APIs, which include a position from
+  an external source like GPS, along with the Wifi, Cell, and Bluetooth
+  :term:`stations` that were seen.
+* **Location queries**, from the geolocate and region APIs, which include an
+  estimated position, along with the stations.
+
+Multiple reports can be submitted in one call to the submission APIs. Each batch
+of reports increment the `data.batch.upload`_ metric when the API is called. A
+single report is created for each location query, and there is no corresponding
+metric.
+
+The APIs feed these :term:`reports` into a Redis queue ``update_incoming``,
+processed by the backend task of the same name. This task copies reports to
+"export" queues. Four types are supported:
+
+* ``dummy``: Does nothing, for pipeline testing
+* ``geosubmit``: POST reports to a service supporting the
+  :ref:`Geosubmit API <api_geosubmit_latest>`.
+* ``internal``: Divide :term:`reports` into :term:`observations`,
+  for further processing to update the internal database.
+* ``s3``: Store report JSON in S3.
+
+Ichnaea supports multiple export targets for a type. In production,
+there are three export targets, identified by an export key:
+
+* ``backup``: An ``s3`` export, to a Mozilla-private S3 bucket
+* ``tostage``: A ``geosubmit`` export, to send a sample of reports to
+  stage for integration testing.
+* ``internal``: An ``internal`` export, to update the database
+
+The data pipeline has not been converted to structured logging. As data
+moves through this part of the data pipeline, these metrics are emitted:
+
+data.export.batch
+^^^^^^^^^^^^^^^^^
+``data.export.batch`` is a counter of the report batches exported to external
+and internal targets.
+
+Tags:
+
+* ``key``: The export key, from the export table. Keys used in Mozilla
+  production:
+
+  - ``backup``: Reports archived in S3
+  - ``tostage``: Reports sent from production to stage, as a form of integration testing
+  - ``internal``: Reports queued for processing to update the internal station database
+
+data.export.upload
+^^^^^^^^^^^^^^^^^^
+``data.export.upload`` is a counter that tracks the status of export jobs.
+
+Tags:
+
+* ``key``: The export key, from the export table. Keys used in Mozilla
+  production are ``backup`` and ``tostage``, with the same meaning as
+  data.export.batch_. Unlike that metric, ``internal`` is not used.
+* ``status``: The status of the export, which varies by type of export:
+
+  - ``backup`` (S3): ``success`` or ``failure``
+  - ``tostage`` (Submission API): HTTP code, usually ``200`` for success, ``400`` for failure.
+
+data.export.upload.timing
+^^^^^^^^^^^^^^^^^^^^^^^^^
+``data.export.upload.timing`` is a timer for the report batch export process.
+
+Tags:
+
+* ``key``: The export key, from the export table. See data.export.batch_ for
+  the values used in Mozilla production.
+
+data.observation.drop
+^^^^^^^^^^^^^^^^^^^^^
+``data.observation.drop`` is a counter of the Bluetooth, cell, or WiFi
+:term:`observations` that were discarded before integration due to some
+internal consistency, range or validity-condition error encountered while
+attempting to normalize the observation.
+
+Tags:
+
+* ``key``: The API key, often a UUID. Omitted if unknown or not available
+* ``type``: The :term:`station` type, one of ``blue``, ``cell``, or ``wifi``
+
+data.observation.upload
+^^^^^^^^^^^^^^^^^^^^^^^
+``data.observation.upload`` is a counter of the number of Bluetooth, cell or
+WiFi :term:`observations` entering the data processing pipeline, before
+normalization and blocked station processing have been applied. This count is
+taken after a batch of :term:`reports` are decomposed into observations.
+
+The tags (``key`` and ``type``) are the same as `data.observation.drop`_.
+
+data.report.drop
+^^^^^^^^^^^^^^^^
+``data.report.drop`` is a counter of the :term:`reports` discarded due to
+some internal consistency, range, or validity-condition error.
+
+Tags:
+
+* ``key``: The API key, often a UUID. Omitted if unknown or not available
+
+data.report.upload
+^^^^^^^^^^^^^^^^^^
+``data.report.upload`` is a counter of the :term:`reports` accepted into the data
+processing pipeline.
+
+It has the same tag (``key``) as `data.report.drop`_.
+
+Data Pipeline Metrics - Update Internal Database
+------------------------------------------------
+The internal export process decomposes :term:`reports` into
+:term:`observations`, pairing one position with one :term:`station`. Each
+observation works its way through a process of normalization,
+consistency-checking, and (possibly) integration into the database, to improve
+future location estimates.
+
+The data pipeline has not been converted to structured logging. As data moves
+through the pipeline, these metrics are emitted:
+
+data.observation.insert
+^^^^^^^^^^^^^^^^^^^^^^^
+``data.observation.insert`` is a counter of the Bluetooth, cell, or WiFi
+:term:`observations` that were successfully validated, normalized, integrated.
+
+Tags:
+
+* ``type``: The :term:`station` type, one of ``blue``, ``cell``, or ``wifi``
+
+data.station.blocklist
+^^^^^^^^^^^^^^^^^^^^^^
+``data.station.blocklist`` is a counter of the Bluetooth, cell, or WiFi
+:term:`stations` that are blocked from being used to estimate positions.
+These are added because there are multiple valid :term:`observations` at
+sufficiently different locations, supporting the theory that it is a
+mobile station (such as a picocell or mobile hotspot on a public transit
+vehicle), or was recently moved (a WiFi base station that moved with the
+owner to a new home).
+
+Tags:
+
+* ``type``: The :term:`station` type, one of ``blue``, ``cell``, or ``wifi``
+
+data.station.confirm
+^^^^^^^^^^^^^^^^^^^^
+``data.station.confirm`` is a counter of the Bluetooth, cell or WiFi
+:term:`stations` that were confirmed to still be active. An :term:`observation`
+from a location query can be used to confirm a station with a position based
+on submission reports.
+
+It has the same tag (``type``) as data.station.blocklist_
+
+data.station.dberror
+^^^^^^^^^^^^^^^^^^^^
+``data.station.dberror`` is a counter of retryable database errors, which are
+encountered as multiple task threads attempt to update the internal database.
+
+Retryable database errors, like a lock timeout (``1205``) or deadlock
+(``1213``) cause the station updating task to sleep and start over.  Other
+database errors are not counted, but instead halt the task and are recorded in
+Sentry.
+
+Tags:
+
+* ``errno``: The error number, which can be found in the 
+  `MySQL Server Error Reference`_.
+* ``type``: The :term:`station`, one of ``blue``, ``cell``, or ``wifi``,
+  or the aggregate station type ``cellarea``.
 
 .. _`MySQL Server Error Reference`: https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html
+
+data.station.new
+^^^^^^^^^^^^^^^^
+``data.station.new`` is a counter of the Bluetooth, cell or WiFi
+:term:`stations` that were discovered for the first time.
+
+Tags:
+
+* ``type``: The :term:`station` type, one of ``blue``, ``cell``, or ``wifi``
+
+Backend Monitoring Metrics
+--------------------------
+
+queue
+^^^^^
+``queue`` is a gauge that reports the current size of task and data queues.
+Queues are implemented as Redis lists, with a length returned by LLEN_.
+
+.. _LLEN: https://redis.io/commands/llen
+
+Task queues hold the backlog of celery async tasks. The names of the task
+queues are:
+
+* ``celery_blue``, ``celery_cell``, ``celery_wifi`` - A task to process a chunk
+  of :term:`observation` data
+* ``celery_default`` - A generic task queue
+* ``celery_export`` - Tasks exporting data, either public cell data or the
+  `Data Pipeline <Data Pipeline Metrics - Gather and Export>`_
+* ``celery_incoming`` - Unused
+* ``celery_monitor`` - Tasks updating metrics gauges for this metric and
+  `API Monitoring Metrics`_
+* ``celery_reports`` - Tasks handling batches of submission reports or location
+  queries
+
+Data queues are the backlog of :term:`observations` and other data items to be
+processed.  Data queues have names that mirror the shared database tables:
+
+* ``update_blue_0`` through ``update_blue_f`` (16 total) - Observations of
+  Bluetooth stations
+* ``update_cell_gsm``, ``update_cell_lte``, and ``update_cell_wcdma`` -
+  Observations of cell stations
+* ``update_cell_area`` - Aggregated observations of cell towers
+* ``update_datamap_ne``, ``update_datamap_nw``, ``update_datamap_se``, and
+  ``update_datamap_sw`` - Approximate locations for the contribution map
+* ``update_wifi_0`` through ``update_wifi_f`` (16 total) - Observations of
+  WiFi stations
+
+Tags:
+
+* ``queue``: The name of the task or data queue
+
+task
+^^^^
+``task`` is a timer that measures how long each Celery task takes. Celery tasks
+are used to implement the data pipeline and monitoring tasks.
+
+Tags:
+
+* ``task``: The task name, such as ``data.export_reports`` or
+  ``data.update_statcounter``.
+
+Datamaps Metrics
+================
+The datamap script generates a data map from the gathered map statistics. It has
+not been updated to work with current production infrastructure, so these metrics
+were emitted from the previous infrastructure.
+
+datamaps
+--------
+``datamaps`` is a timer for functions in the datamap process. It also counts items,
+but as a timer.
+
+.. NOTE::
+   The item counts should be moved to a new counter metric
+
+Tags:
+
+* ``func``: The export function being timed, such as ``export``, ``encode``,
+  ``merge``, ``main``, ``render``, or ``upload``
+* ``count``: The item counts, recorded as a timer, such as ``csv_rows``,
+  ``quadtrees``, ``tile_new``, ``tile_changed``, ``tile_deleted``, ``tile_unchanged``
+
+datamaps.dberror
+^^^^^^^^^^^^^^^^
+``datamaps.dberror`` counts the number of retryable database errors.
+
+Tags:
+
+* ``errno``: The error number, same as `data.station.dberror`_
+
+Implementation
+==============
+
+Ichnaea emits statsd-compatible metrics using markus_, if the ``STATSD_HOST``
+is configured (see :ref:`the config section <config>`). Metrics use the the
+tags extension, which add queryable dimensions to the metrics. In development,
+the metrics are displayed with the logs. In production, metrics are stored in
+an InfluxDB_ database, and can be displayed as graphs with Grafana_.
+
+.. _markus: https://markus.readthedocs.io/en/latest/
+.. _InfluxDB: https://docs.influxdata.com/influxdb/v1.8/
+.. _Grafana: https://grafana.com/docs/grafana/latest
+
+Ichnaea also emits structured logs using structlog_.  In development, these are
+displayed in a human-friendly format. In production, they use the MozLog_ JSON
+format, and the data is stored in BigQuery_.
+
+.. _structlog: https://www.structlog.org/en/stable/
+.. _MozLog: https://wiki.mozilla.org/Firefox/Services/Logging
+.. _BigQuery: https://cloud.google.com/bigquery/docs/
+
+In the past, metrics were the main source of runtime data, and tags were used
+to segment the metrics and provide insights. However, metric tags and their
+values were limited to avoid performance issues. InfluxDB and other time-series
+databases store metrics by the indexed series of tag values. This performs well
+when tags have a small number of unique values, and the combinations of tags
+are limited.  When tags have many unique values and are combined, the number of
+possible series can explode and cause storage and performance issues (the
+"high cardinality" problem).
+
+Metric tag values are limited to avoid high cardinality issues. For example,
+rather than storing the number of WiFi stations, the ``wifi`` tag of the
+`locate.query`_ metric has the values ``none``, ``one``, and ``many``. The
+region, such as ``US`` or ``DE``, was once stored as a tag, but this can have
+almost 250 values.
+
+BigQuery easily handles high-cardinality data, so structured logs can contain
+precise values, such as the actual number of WiFi stations provided, and more
+items, such as the region and unexpected keys. On the other hand, there isn't a
+friendly tool like Grafana to quickly explore the data.
+
+As of 2020, we are in the process of duplicating data from metrics into
+structured logging, expanding the data collected, and creating
+dashboards. We'll also remove data from metrics, first to reduce the current
+issues around high-cardinality, then to focus metrics on operational data.
+Structured data will be used for service analysis and monitoring of long-term
+trends, and dashboards created for reference.
+


### PR DESCRIPTION
Rewrite the metrics document and expand it to cover structured logs:

* Describe the difference between statsd metrics and structured logging
* Create an Implementation section, to describe our implementation, the issues around high cardinality, and that this is all in progress
* Instead of the narrative flow, split up metrics by web app, task app, and datamaps, with some secondary sections as needed, and a new section for web app structured logs.
* Split up metrics to a section per metric, with a new style for documenting tags, and with cross-references to structure logs
* Reorganize backend and pipeline sections, and add more context. Some of this is duplicated on the data flows page, and could be merged.

All of this makes the diff view fairly useless for reviewing this change (except for the metrics table, which gained ``region.query``). A reviewer may want to cross-reference to the [current metrics document](https://ichnaea.readthedocs.io/en/latest/metrics.html) instead.