### PR TITLE
Switch to dependabot v2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,9 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "python"
-    directory: "/"
-    update_schedule: "monthly"
-
-  - package_manager: "docker"
-    directory: "/"
-    update_schedule: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    reviewers:
+      - jwhitlock
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    reviewers:
+      - jwhitlock


### PR DESCRIPTION
Switch from the dependabot-preview spec to the current version.

Based on https://github.com/mozilla-services/antenna/pull/635. @willkg does this look correct?