### PR TITLE
CircleCI config updates: Specify remote docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ jobs:
         - store_artifacts:
             path: /ichnaea/version.json
 
-        - setup_remote_docker
+        - setup_remote_docker:
+            version: 19.03.13
 
         - run:
             name: Get Info


### PR DESCRIPTION
As discussed [here](https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572), CircleCI is deprecating older machine images. This includes the image
``docker-17.09.0-ce image``, which is the default for the ``"setup_remote_docker"`` step. Replace it with ~(the recommended Ubuntu 16.04 image)~ 19.03.13, the [latest available version](https://circleci.com/docs/2.0/building-docker-images/#docker-version) and the one I'm running locally.