### PR TITLE
CircleCI: Use docker auth instead of direct login

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: mozilla/cidockerbases:docker-latest
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     working_directory: /
 
     steps:
@@ -65,12 +68,6 @@ jobs:
             name: Push to Dockerhub
             working_directory: /ichnaea
             command: |
-              # Quit early if docker credentials are not defined
-              if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
-                echo "Skipping Push to Dockerhub, credentials not available."
-                exit 0
-              fi
-
               function retry {
                 set +e
                 local n=0
@@ -95,7 +92,6 @@ jobs:
               fi
               # push on main or git tag
               if [ "${CIRCLE_BRANCH}" == "main" ] || [ -n "${CIRCLE_TAG}" ]; then
-                echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
                 docker tag "local/ichnaea_app" "mozilla/location:${DOCKER_TAG}"
                 retry docker push "mozilla/location:${DOCKER_TAG}"
 


### PR DESCRIPTION
Apply authentication in the ``docker:auth`` section instead of as an explicit shell command during step "Push to Dockerhub". The authenticated connection will also avoid rate limiting for Docker image pulls during the step "Build Docker images".

Maybe.

This investigates the question raised at https://github.com/mozilla/ichnaea/pull/1369#pullrequestreview-502381253, if the login for ``docker: auth`` applies for the full CI run. We may only see the results when it is merged to main and the code attempts to push to Dockerhub. If it works, then the commit message will be correct. Otherwise, we'll need to revert and do something more like PR #1369.