### PR TITLE
Updates for new mailing list and preferred issue tracker

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,9 +12,9 @@ for both discussions and talking about new features or bugs. You can
 also fork the project and send us a pull request.
 
 If you have a more general topic to discuss, the
-`dev-geolocation@lists.mozilla.org
-<https://lists.mozilla.org/listinfo/dev-geolocation>`_
-mailing list is a good place to do so.
+`Location category
+<https://discourse.mozilla.org/c/location/506>`_
+is a good place to do so.
 
 
 Development

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,11 +5,11 @@ How to contribute
 We gladly accept outside contributions.
 
 We use
-`Bugzilla <https://bugzilla.mozilla.org/buglist.cgi?product=Location&component=General&bug_status=__open__>`_
-and our
 `Github issue tracker <https://github.com/mozilla/ichnaea/issues>`_
-for both discussions and talking about new features or bugs. You can
-also fork the project and send us a pull request.
+for both discussions and talking about new features or bugs. For
+confidential issues or security bugs, please use
+`Bugzilla <https://bugzilla.mozilla.org/buglist.cgi?product=Location&component=General&bug_status=__open__>`_.
+You can also fork the project and send us a pull request.
 
 If you have a more general topic to discuss, the
 `Location category

--- a/contribute.json
+++ b/contribute.json
@@ -9,7 +9,7 @@
     "participate": {
         "home": "https://location.services.mozilla.com/",
         "docs": "https://ichnaea.readthedocs.io/",
-        "mailing-list": "https://groups.google.com/group/mozilla.dev.geolocation"
+        "mailing-list": "https://discourse.mozilla.org/c/location/506"
     },
     "bugs": {
         "list": "https://github.com/mozilla/ichnaea/issues",

--- a/contribute.json
+++ b/contribute.json
@@ -9,7 +9,11 @@
     "participate": {
         "home": "https://location.services.mozilla.com/",
         "docs": "https://ichnaea.readthedocs.io/",
-        "mailing-list": "https://discourse.mozilla.org/c/location/506"
+        "mailing-list": "https://discourse.mozilla.org/c/location/506",
+        "chat": {
+            "url": "https://chat.mozilla.org/#/room/#location:mozilla.org",
+            "contacts": ["jwhitlock"]
+        }
     },
     "bugs": {
         "list": "https://github.com/mozilla/ichnaea/issues",

--- a/docker/node/package.json
+++ b/docker/node/package.json
@@ -2,7 +2,6 @@
   "name": "ichnaea",
   "version": "0.0.0",
   "private": true,
-  "author": "Mozilla <dev-geolocation@lists.mozilla.org>",
   "repository": {
     "type": "git",
     "url": "https://github.com/mozilla/ichnaea.git"

--- a/ichnaea/content/templates/contact.pt
+++ b/ichnaea/content/templates/contact.pt
@@ -16,9 +16,13 @@
 
     <p>
         If you have a question about the Mozilla Location Service,
-        post to
-        <a href="https://groups.google.com/group/mozilla.dev.geolocation">
-            our public mailing list</a>.
+        post to the
+        <a href="https://discourse.mozilla.org/c/location/506">
+            Location category</a>
+        on
+        <a href="https://discourse.mozilla.org">
+            Mozilla Discourse</a>.
+
     </p>
     <p>
         If your inquiry about the Mozilla Location Service should stay

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     long_description=long_description,
     url='https://github.com/mozilla/ichnaea',
     author='Mozilla',
-    author_email='dev-geolocation@lists.mozilla.org',
     license="Apache 2.0",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
For issue #1406, replace most links to the [dev-geolocation mailing list](https://lists.mozilla.org/listinfo/dev-geolocation) with links to the [Location category](https://discourse.mozilla.org/c/location/506) on Discourse. For other instances, just remove the link or the mailing list email address.

Also, add a link to the [location chat room](https://chat.mozilla.org/#/room/#location:mozilla.org). I will try to remember to check it periodically.

For issue #1374, switch the text to prefer GitHub issues, but use Bugzilla for confidential and security issues.

