### PR TITLE
issue #1417: Add libs for scipy and Py 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,13 @@ RUN apt-key add /tmp/mysql_pubkey.asc && \
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \
     file \
-    gcc \
     g++ \
+    gcc \
+    gfortran \
+    libatlas-base-dev \
     libffi-dev \
     libgeos-dev \
+    liblapack-dev \
     libmysqlclient-dev \
     libpng-dev \
     libprotobuf-dev \


### PR DESCRIPTION
``scipy`` fails to build under Python 3.9, because wheels are not yet ready and the source build can't load lapack/blas resources:

```
numpy.distutils.system_info.NotFoundError: No lapack/blas resources found.
```

This adds the ``gfortran``, ``liblapack-dev``, and ``libatlas-base-dev`` libraries, needed to build from source, as seen in the [bleeding edge](https://github.com/scipy/scipy/blob/master/.github/workflows/bleedingedge.yml#L32) build.