### PR TITLE
Specify Python 3.6 or later

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [bdist_wheel]
 universal=0
 
+[options]
+python_requires = >=3.6
+
 [flake8]
 ignore =
     # E203: Whitespace before ':'; doesn't work with black


### PR DESCRIPTION
Dependabot may use this as a hint to use Python 3.6 when determining what requirements to install. 

See issue #1428.