### PR TITLE
Use Sphinx 3.2.1 in Read the Docs

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
 # Requirements to build documentation
-Sphinx
+Sphinx >= 3.2.1
 everett


### PR DESCRIPTION
Just specifying `Sphinx` is not enough, because RTD installs `Sphinx < 2` first.

This broke while trying to fix issue #1428.