### PR TITLE
Dependency Updates, December 2020, Round 2: Development dependencies

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
 # Requirements to build documentation
-Sphinx >= 3.2.1
+Sphinx==3.3.1
 everett

--- a/requirements.in
+++ b/requirements.in
@@ -216,7 +216,7 @@ black==20.8b1
 # Code: https://github.com/tartley/colorama
 # Changes: https://github.com/tartley/colorama/blob/master/CHANGELOG.rst
 # Docs: https://github.com/tartley/colorama#readme
-colorama==0.4.3
+colorama==0.4.4
 
 # Compiler for writing C extensions for Python
 # Code: https://github.com/cython/cython
@@ -228,7 +228,7 @@ Cython==0.29.21
 # Code: https://github.com/FactoryBoy/factory_boy/
 # Changes: https://factoryboy.readthedocs.io/en/stable/changelog.html
 # Docs: https://factoryboy.readthedocs.io/en/stable/
-factory-boy==3.0.1
+factory-boy==3.1.0
 
 # Run a collection of style and quality tools
 # Code: https://gitlab.com/pycqa/flake8
@@ -240,13 +240,13 @@ flake8==3.8.4
 # Code: https://github.com/jazzband/pip-tools/
 # Changes: https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md
 # Docs: https://github.com/jazzband/pip-tools#readme
-pip-tools==5.3.1
+pip-tools==5.4.0
 
 # Test framework
 # Code: https://github.com/pytest-dev/pytest
 # Changes: https://docs.pytest.org/en/stable/changelog.html
 # Docs: https://docs.pytest.org/en/stable/
-pytest==6.1.1
+pytest==6.1.2
 
 # Code coverage plugin for pytest
 # Code: https://github.com/pytest-dev/pytest-cov
@@ -264,7 +264,7 @@ requests-mock==1.8.0
 # Code: https://github.com/sphinx-doc/sphinx/
 # Changes: https://www.sphinx-doc.org/en/master/changes.html
 # Docs: https://www.sphinx-doc.org/en/master/
-Sphinx==3.2.1
+Sphinx==3.3.1
 
 # ReadTheDocs theme for Sphinx
 # Code: https://github.com/readthedocs/sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,9 +163,9 @@ colander==1.8.2 \
     --hash=sha256:498670aa97d632e04268cfdc0d7d25bba2acbc790b7637fb358022d6508a3c14 \
     --hash=sha256:54878d2ffd1afb020daca6cd5c6cfe6c0e44d0069fc825d57fe59aa6e4f6a499 \
     # via -r requirements.in
-colorama==0.4.3 \
-    --hash=sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff \
-    --hash=sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1 \
+colorama==0.4.4 \
+    --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b \
+    --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2 \
     # via -r requirements.in
 coverage==5.3 \
     --hash=sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516 \
@@ -284,8 +284,9 @@ everett==1.0.2 \
     --hash=sha256:66c7991c056fd9b1de54c29e2b5004a30209530faef698d6ecfbf24bfbbdd1fb \
     --hash=sha256:8a5ee8cdde0ed6b3bbb63249e0e0703d4ad91921107ff198e0868ffce5f7b6bc \
     # via -r requirements.in
-factory-boy==3.0.1 \
-    --hash=sha256:2ce2f665045d9f15145a6310565fcb8255d52fc6fd867f3b783b3ac3de6cf10e \
+factory-boy==3.1.0 \
+    --hash=sha256:d8626622550c8ba31392f9e19fdbcef9f139cf1ad643c5923f20490a7b3e2e3d \
+    --hash=sha256:ded73e49135c24bd4d3f45bf1eb168f8d290090f5cf4566b8df3698317dc9c08 \
     # via -r requirements.in
 faker==5.0.0 \
     --hash=sha256:7bca5b074299ac6532be2f72979e6793f1a2403ca8105cb4cf0b385a964469c4 \
@@ -578,9 +579,9 @@ pathspec==0.8.1 \
     --hash=sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd \
     --hash=sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d \
     # via black
-pip-tools==5.3.1 \
-    --hash=sha256:5672c2b6ca0f1fd803f3b45568c2cf7fadf135b4971e7d665232b2075544c0ef \
-    --hash=sha256:73787e23269bf8a9230f376c351297b9037ed0d32ab0f9bef4a187d976acc054 \
+pip-tools==5.4.0 \
+    --hash=sha256:a4d3990df2d65961af8b41dacc242e600fdc8a65a2e155ed3d2fc18a5c209f20 \
+    --hash=sha256:b73f76fe6464b95e41d595a9c0302c55a786dbc54b63ae776c540c04e31914fb \
     # via -r requirements.in
 plaster-pastedeploy==0.7 \
     --hash=sha256:391d93a4e1ff81fc3bae27508ebb765b61f1724ae6169f83577f06b6357be7fd \
@@ -645,9 +646,9 @@ pytest-cov==2.10.1 \
     --hash=sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191 \
     --hash=sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e \
     # via -r requirements.in
-pytest==6.1.1 \
-    --hash=sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9 \
-    --hash=sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92 \
+pytest==6.1.2 \
+    --hash=sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe \
+    --hash=sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e \
     # via -r requirements.in, pytest-cov
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
@@ -792,9 +793,9 @@ sphinx-rtd-theme==0.5.0 \
     --hash=sha256:22c795ba2832a169ca301cd0a083f7a434e09c538c70beb42782c073651b707d \
     --hash=sha256:373413d0f82425aaa28fb288009bf0d0964711d347763af2f1b65cafcb028c82 \
     # via -r requirements.in
-sphinx==3.2.1 \
-    --hash=sha256:321d6d9b16fa381a5306e5a0b76cd48ffbc588e6340059a729c6fdd66087e0e8 \
-    --hash=sha256:ce6fd7ff5b215af39e2fcd44d4a321f6694b4530b6f2b2109b64d120773faea0 \
+sphinx==3.3.1 \
+    --hash=sha256:1e8d592225447104d1172be415bc2972bd1357e3e12fdc76edf2261105db4300 \
+    --hash=sha256:d4e59ad4ea55efbb3c05cde3bfc83bfc14f0c95aa95c3d75346fcce186a47960 \
     # via -r requirements.in, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2 \
     --hash=sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a \


### PR DESCRIPTION
* colorama 0.4.3 → 0.4.4: Fix OSC regex, project changes
* factory-boy 3.0.1 → 3.1.0: Fix for importing framework-specific
  factories
* pip-tools 5.3.1 → 5.4.0: pip 20.3 support
* pytest 6.1.1 → 6.1.2: Bug fixes
* sphinx 3.2.1 → 3.3.1: Bug fixes, deprecations