### PR TITLE
Documentation fixes

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -104,7 +104,10 @@ request.timing
 ``request.timing`` is a timer for how long the HTTP request took to complete in
 milliseconds.
 
-The tags (``path``, ``method``, and ``status``) are the same as `request`_.
+Tags:
+
+The tags ``path`` and ``method`` are the same as `request`_. The tag ``status``
+is omitted.
 
 Related structured log data:
 

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -837,15 +837,16 @@ Tags:
 Rate Control Metrics
 --------------------
 
-The optional `rate controller <rate-control>`_ can be used to dynamically set
-the global locate sample rate and prevent the data queues from growing without
-bounds. There are several metrics emitted to monitor the rate controller.
+The optional :ref:`rate controller <auto-rate-controller>` can be used to
+dynamically set the global locate sample rate and prevent the data queues from
+growing without bounds. There are several metrics emitted to monitor the rate
+controller.
 
 rate_control.locate
 ^^^^^^^^^^^^^^^^^^^
 ``rate_control.locate`` is a gauge that reports the current setting of the
-`global locate sample rate <global-rate-control>`_, which may be unset (100.0),
-manually set, or set by the rate controller.
+:ref:`global locate sample rate <global-rate-control>`, which may be unset
+(100.0), manually set, or set by the rate controller.
 
 rate_control.locate.target
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/rate_control.rst
+++ b/docs/rate_control.rst
@@ -74,7 +74,7 @@ An administrator can use these to limit the observations from large API users,
 or to ignore traffic from questionable API users. The default is 100% (all
 locate and submission observations) for new API keys.
 
-.. global-rate-control:
+.. _global-rate-control:
 
 Global Rate Control
 ===================
@@ -85,13 +85,13 @@ applied as a multiple on any API key controls, so if an API has
 the effective sample rate for that API key is 30%.
 
 An administrator can use this control to globally limit observations from
-`geolocate <api_geolocate_latest>`_ calls. A temporary rate of 0% is an
+:ref:`geolocate <api_geolocate_latest>` calls. A temporary rate of 0% is an
 effective way to allow the backend to process a large backlog of observations.
 If unset, the default global rate is 100%.
 
 There is no global rate control for submissions.
 
-.. rate_control:
+.. _auto-rate-controller:
 
 Automated Rate Control (Beta)
 =============================
@@ -105,15 +105,15 @@ To enable the rate controller:
 1. Set the Redis key ``rate_controller_target`` to the desired maximum queue
    size, such as ``1000000`` for 1 million observations. A suggested value is
    5-10 minutes of maximum observation processing, as seen by summing the
-   `data.observation.insert metric <data.observation.insert-metric>`_ during
-   peak periods with a backlog.
+   :ref:`data.observation.insert metric <data.observation.insert-metric>`
+   during peak periods with a backlog.
 2. Set the Redis key ``rate_controller_enabled`` to ``1`` to enable or ``0``
    to disable the rate controller. If the rate controller is enabled without
    a target, it will be automatically disabled.
 
 The rate controller runs once a minute, at the same time that
-`queue metrics <queue-metric>`_ are emitted. The rate is adjusted during the
-peak traffic to keep the backlog near the target rate, and the backlog is
+:ref:`queue metrics <queue-metric>` are emitted. The rate is adjusted during
+the peak traffic to keep the backlog near the target rate, and the backlog is
 more quickly processed when the peak ends.
 
 .. Source document:
@@ -169,7 +169,7 @@ The gain parameters are stored in Redis keys, and can be adjusted:
   simulation, this had little noticable effect, and may require a value of
   50.0 or higher to see any changes.
 
-The rate controller emits several `metrics <rate-controller-metrics>`_.
+The rate controller emits several :ref:`metrics <rate-control-metrics>`.
 An administrator can use these metrics to monitor the rate controller, and to
 determine if backend resources should be increased or decreased based on
 long-term traffic trends.


### PR DESCRIPTION
As part of setting up dashboards for issue #1398, I noticed some issues in new and old documents.

``request.timing`` says it has the same ``status`` tag as ``request``, but it doesn't. I considered adding the tag to ``request.timing``, but we can do similar analysis with log data and BigQuery. Updated the documentation to reflect the code.

The rate control document cross-linked to references in the metrics document and vice-versa, which requires the Sphinx `:ref:` directive. With the `underscore_` method, the links were unchecked 404 links. `:ref:` added and anchors fixed or adjusted.