### PR TITLE
Update from node 8.x to 14.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
       interval: monthly
     reviewers:
       - jwhitlock
+  - package-ecosystem: docker
+    directory: /docker/node/
+    schedule:
+      interval: monthly
+    reviewers:
+      - jwhitlock
+  - package-ecosystem: npm
+    directory: /docker/node/
+    schedule:
+      interval: monthly
+    reviewers:
+      - jwhitlock

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:14-slim
 
 # Note: This uses the node user (uid 1000) that comes with the image.
 


### PR DESCRIPTION
Update node from 8.x to 14.x (issue #1390), with no package updates. Enable Dependabot for the Dockerfile and for the npm packages.

Node is used to install javascript libraries like jquery and mapbox, and to combine and minify CSS and JS for the website. It is not run in production.

