### PR TITLE
Replace more pytz with zoneinfo

### DIFF
--- a/ichnaea/api/submit/tests/test_submit_v0.py
+++ b/ichnaea/api/submit/tests/test_submit_v0.py
@@ -1,8 +1,8 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import colander
 import pytest
-import pytz
 
 from ichnaea.api.exceptions import ParseError
 from ichnaea.api.submit.schema_v0 import SUBMIT_V0_SCHEMA
@@ -197,7 +197,7 @@ class TestView(BaseSubmitTest):
         assert item["api_key"] == "test"
         report = item["report"]
         timestamp = datetime.utcfromtimestamp(report["timestamp"] / 1000.0)
-        timestamp = timestamp.replace(microsecond=0, tzinfo=pytz.UTC)
+        timestamp = timestamp.replace(microsecond=0, tzinfo=ZoneInfo("UTC"))
         assert timestamp == today
         position = report["position"]
         assert position["latitude"] == cell.lat

--- a/ichnaea/models/sa_types.py
+++ b/ichnaea/models/sa_types.py
@@ -1,8 +1,8 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 import time
 
 from enum import IntEnum
-import pytz
 from sqlalchemy import String
 from sqlalchemy.dialects.mysql import DATETIME as DateTime, TINYINT as TinyInteger
 from sqlalchemy.types import TypeDecorator
@@ -66,5 +66,5 @@ class TZDateTime(TypeDecorator):
     def process_result_value(self, value, dialect):
         if value is not None:
             ts = time.mktime(value.timetuple())
-            value = datetime.fromtimestamp(ts).replace(tzinfo=pytz.UTC)
+            value = datetime.fromtimestamp(ts).replace(tzinfo=ZoneInfo("UTC"))
         return value

--- a/requirements.in
+++ b/requirements.in
@@ -122,11 +122,6 @@ pyramid==1.10.5
 # Docs: https://docs.pylonsproject.org/projects/pyramid_chameleon/en/latest/
 pyramid-chameleon==0.3
 
-# Timezone calculations and the Olson timezone database
-# Code: https://launchpad.net/pytz#
-# Docs: https://pythonhosted.org/pytz/
-pytz==2020.4
-
 # Legacy client library for Sentry crash reporting server
 # TODO: Replace with sentry-sdk (issue #882)
 # Code: https://github.com/getsentry/raven-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -679,7 +679,7 @@ python-editor==1.0.4 \
 pytz==2020.4 \
     --hash=sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268 \
     --hash=sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd \
-    # via -r requirements.in, babel, celery
+    # via babel, celery
 raven==6.10.0 \
     --hash=sha256:3fa6de6efa2493a7c827472e984ce9b020797d0da16f1db67197bcc23c8fae54 \
     --hash=sha256:44a13f87670836e153951af9a3c80405d36b43097db869a36e92809673692ce4 \


### PR DESCRIPTION
For issue #1440, replace a few more instances of ``pytz`` in the code, then remove it from the primary requirements file. ``pytz`` is still used by babel and celery, so it will continue to be installed.