### PR TITLE
parsing for British Indian Ocean Territory

### DIFF
--- a/mobile_codes/parse.py
+++ b/mobile_codes/parse.py
@@ -45,6 +45,8 @@ def parse_wikipedia(source_dir):
                     "table", class_="wikitable", attrs={"width": "100%"}
                 ):
                     hs = table.find_previous_sibling("h4")
+					if hs is None:
+						hs = table.find_previous_sibling("h3")
                     iso = ""
                     if hs is not None:
                         hs = hs.find("span", class_="mw-headline")
@@ -63,6 +65,8 @@ def parse_wikipedia(source_dir):
                             )
                             if iso == "GE-AB":
                                 iso = "GE"
+							if iso == "British Indian Ocean Territory":
+								iso = "IO"
                             if "-" in iso:
                                 print(
                                     "Another iso with region code, please check !: "

--- a/mobile_codes/parse.py
+++ b/mobile_codes/parse.py
@@ -45,8 +45,8 @@ def parse_wikipedia(source_dir):
                     "table", class_="wikitable", attrs={"width": "100%"}
                 ):
                     hs = table.find_previous_sibling("h4")
-					if hs is None:
-						hs = table.find_previous_sibling("h3")
+                    if hs is None:
+                        hs = table.find_previous_sibling("h3")
                     iso = ""
                     if hs is not None:
                         hs = hs.find("span", class_="mw-headline")
@@ -65,8 +65,8 @@ def parse_wikipedia(source_dir):
                             )
                             if iso == "GE-AB":
                                 iso = "GE"
-							if iso == "British Indian Ocean Territory":
-								iso = "IO"
+                            if iso == "British Indian Ocean Territory":
+                                iso = "IO"
                             if "-" in iso:
                                 print(
                                     "Another iso with region code, please check !: "


### PR DESCRIPTION
In addition to #1421 add an exceptional parsing for British Indian Ocean Territory.
This will replace the null mccs list in the countries.json for "British Indian Ocean Territory" to "995"