### PR TITLE
Dependency updates for January 2020

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -245,7 +245,7 @@ iso3166
 # Code: https://github.com/jazzband/pip-tools/
 # Changes: https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md
 # Docs: https://github.com/jazzband/pip-tools#readme
-pip-tools==5.4.0
+pip-tools==5.5.0
 
 # Test framework
 # Code: https://github.com/pytest-dev/pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -596,9 +596,9 @@ pathspec==0.8.1 \
     --hash=sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd \
     --hash=sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d \
     # via black
-pip-tools==5.4.0 \
-    --hash=sha256:a4d3990df2d65961af8b41dacc242e600fdc8a65a2e155ed3d2fc18a5c209f20 \
-    --hash=sha256:b73f76fe6464b95e41d595a9c0302c55a786dbc54b63ae776c540c04e31914fb \
+pip-tools==5.5.0 \
+    --hash=sha256:10841c1e56c234d610d0466447685b9ea4ee4a2c274f858c0ef3c33d9bd0d985 \
+    --hash=sha256:cb0108391366b3ef336185097b3c2c0f3fa115b15098dafbda5e78aef70ea114 \
     # via -r requirements.in
 plaster-pastedeploy==0.7 \
     --hash=sha256:391d93a4e1ff81fc3bae27508ebb765b61f1724ae6169f83577f06b6357be7fd \
@@ -839,7 +839,7 @@ simple-pid==0.2.4 \
 six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
-    # via click-repl, cryptography, pip-tools, pyopenssl, python-dateutil, requests-mock, structlog, webtest
+    # via click-repl, cryptography, pyopenssl, python-dateutil, requests-mock, structlog, webtest
 snowballstemmer==2.0.0 \
     --hash=sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0 \
     --hash=sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52 \


### PR DESCRIPTION
Update dependencies. This covers:

* Bump pip-tools from 5.4.0 to 5.5.0 (from PR #1477) - Python 3.9, new command line options
* Bump gevent from 20.9.0 to 20.12.1 (from PR #1476) - Add context managers for greenlets
* Bump celery[redis] from 5.0.3 to 5.0.5 (from PR #1475) - Test backend changes
* Bump boto3 from 1.16.30 to 1.16.48 (from PR #1474) - AWS API updates