### PR TITLE
Datamap script: Update logging and switch to low-level S3 client

### DIFF
--- a/ichnaea/log.py
+++ b/ichnaea/log.py
@@ -21,10 +21,19 @@ from ichnaea.util import version_info
 METRICS = markus.get_metrics()
 
 
-def configure_logging():
-    """Configure Python logging."""
-    local_dev_env = settings("local_dev_env")
-    logging_level = settings("logging_level")
+def configure_logging(local_dev_env=None, logging_level=None):
+    """Configure Python logging.
+
+    :param local_dev_env: If True, format logs for humans. If False,
+        use MozLog format for machines. The default is to read the
+        value from settings.
+    :param logging_level: The logging level, such as DEBUG or INFO.
+        The default is to read the value from settings.
+    """
+    if local_dev_env is None:
+        local_dev_env = settings("local_dev_env")
+    if logging_level is None:
+        logging_level = settings("logging_level")
 
     if local_dev_env:
         handlers = ["dev"]

--- a/ichnaea/scripts/datamap.py
+++ b/ichnaea/scripts/datamap.py
@@ -640,6 +640,15 @@ def get_parser():
         # Fallback to the CPU count
         concurrency = os.cpu_count()
     parser = argparse.ArgumentParser(description="Generate and upload datamap tiles.")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help=(
+            "Turn on verbose logging. Equivalent to setting LOCAL_DEV_ENV=1"
+            " and LOGGING_LEVEL=debug"
+        ),
+    )
     parser.add_argument("--create", action="store_true", help="Create tiles")
     parser.add_argument("--upload", action="store_true", help="Upload tiles to S3")
     parser.add_argument(
@@ -712,11 +721,6 @@ def main(_argv=None, _raven_client=None, _bucket_name=None):
     :return: A system exit code
     :rtype: int
     """
-    # Setup basic services
-    configure_logging()
-    raven_client = configure_raven(
-        transport="sync", tags={"app": "datamap"}, _client=_raven_client
-    )
 
     # Parse the command line
     parser = get_parser()
@@ -724,6 +728,16 @@ def main(_argv=None, _raven_client=None, _bucket_name=None):
     create = args.create
     upload = args.upload
     concurrency = args.concurrency
+    verbose = args.verbose
+
+    # Setup basic services
+    if verbose:
+        configure_logging(local_dev_env=True, logging_level="DEBUG")
+    else:
+        configure_logging()
+    raven_client = configure_raven(
+        transport="sync", tags={"app": "datamap"}, _client=_raven_client
+    )
 
     # Check consistent output_dir, create, upload
     exit_early = 0

--- a/ichnaea/scripts/datamap.py
+++ b/ichnaea/scripts/datamap.py
@@ -446,13 +446,13 @@ def sync_tiles(
     LOG.debug(
         f"Completed sync plan in {action_timer.duration_s:0.1f} seconds,"
         f" {len(actions['upload']):,} new"
-        f" tile{'' if len(actions['upload']) == 1 else 0} to upload,"
+        f" tile{'' if len(actions['upload']) == 1 else 's'} to upload,"
         f" {len(actions['update']):,} changed"
-        f" tile{'' if len(actions['update']) == 1 else 0} to update,"
+        f" tile{'' if len(actions['update']) == 1 else 's'} to update,"
         f" {len(actions['delete']):,} orphaned"
-        f" tile{'' if len(actions['delete']) == 1 else 0} to delete,"
+        f" tile{'' if len(actions['delete']) == 1 else 's'} to delete,"
         f" and {len(actions['none']):,} unchanged"
-        f" tile{'' if len(actions['none']) == 1 else 0}"
+        f" tile{'' if len(actions['none']) == 1 else 's'}"
     )
     result = {
         "tile_new": 0,


### PR DESCRIPTION
Update the datamap script with changes from a test run in staging (issue #840):

* Switch from using the high-level [Bucket resource](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucket) to the [low-level client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#client) to access the S3 bucket. Others have had problems with [multiprocessing and the S3 Resource interfaces](https://github.com/boto/boto3/issues/1670), which may accumulate memory due to caches or session accumulation. Others have suggested [the low-level client does not share this problem](https://github.com/boto/botocore/issues/1246#issuecomment-589909285). The Amazon devs are sadly quiet.
* Add a ``--verbose`` option to force the logging options used in local development.
* Add more progress messages for steps that were faster in the dev enviroment but take over a minute on staging. A new helper, ``watch_jobs``, standardizes the job waiting loop.
* Copy-edit some debug messages.