### PR TITLE
Datamap script updates for production

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -905,8 +905,11 @@ The final ``canonical-log-line`` log entry has this data:
 * ``bucket_name``: The name of the S3 bucket
 * ``concurrency``: The number of concurrent threads used
 * ``create``: True if ``--create`` was set to generate tiles
+* ``csv_converted_count``: How many CSV files were exported and converted to quadtrees
 * ``duration_s``: How long in seconds to run the script
 * ``export_duration_s``: How long in seconds to export from tables to CSV
+* ``intermediate_quadtree_count``: How many partial quadtrees were created (due
+  to multiple CSVs exported from large tables) and merged into one per-table quadtree
 * ``merge_duration_s``: How long in seconds to merge the per-table quadtrees
 * ``quadtree_count``: How many per-table quadtrees were generated
 * ``quadtree_duration_s``: How long in seconds to convert CSV to quadtrees

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -905,7 +905,8 @@ The final ``canonical-log-line`` log entry has this data:
 * ``bucket_name``: The name of the S3 bucket
 * ``concurrency``: The number of concurrent threads used
 * ``create``: True if ``--create`` was set to generate tiles
-* ``csv_converted_count``: How many CSV files were exported and converted to quadtrees
+* ``csv_count``: How many CSV files were exported from the database
+* ``csv_converted_count``: How many CSV files were converted to quadtrees
 * ``duration_s``: How long in seconds to run the script
 * ``export_duration_s``: How long in seconds to export from tables to CSV
 * ``intermediate_quadtree_count``: How many partial quadtrees were created (due

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -905,8 +905,8 @@ The final ``canonical-log-line`` log entry has this data:
 * ``bucket_name``: The name of the S3 bucket
 * ``concurrency``: The number of concurrent threads used
 * ``create``: True if ``--create`` was set to generate tiles
-* ``csv_count``: How many CSV files were exported from the database
 * ``csv_converted_count``: How many CSV files were converted to quadtrees
+* ``csv_count``: How many CSV files were exported from the database
 * ``duration_s``: How long in seconds to run the script
 * ``export_duration_s``: How long in seconds to export from tables to CSV
 * ``intermediate_quadtree_count``: How many partial quadtrees were created (due
@@ -922,6 +922,7 @@ The final ``canonical-log-line`` log entry has this data:
 * ``tile_changed``: How many existing S3 tiles were updated
 * ``tile_count``: The total number of tiles generated
 * ``tile_deleted``: How many existing S3 tiles were deleted
+* ``tile_failed``: How many upload or deletion failures
 * ``tile_new``: How many new tiles were uploaded to S3
 * ``tile_unchanged``: How many tiles were the same as the S3 tiles
 * ``upload``: True if ``--upload`` was set to upload / sync tiles

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -902,7 +902,7 @@ not emit metrics.
 
 The final ``canonical-log-line`` log entry has this data:
 
-* ``bucketname``: The name of the S3 bucket
+* ``bucket_name``: The name of the S3 bucket
 * ``concurrency``: The number of concurrent threads used
 * ``create``: True if ``--create`` was set to generate tiles
 * ``duration_s``: How long in seconds to run the script

--- a/ichnaea/scripts/datamap.py
+++ b/ichnaea/scripts/datamap.py
@@ -182,6 +182,7 @@ def generate(
             )
 
         result["sync_duration_s"] = sync_timer.duration_s
+        result["tiles_unchanged"] = unchanged_count
         result.update(sync_counts)
         LOG.debug(
             f"Synced tiles to S3 in {sync_timer.duration_s:0.1f} seconds: "

--- a/ichnaea/scripts/datamap.py
+++ b/ichnaea/scripts/datamap.py
@@ -139,9 +139,9 @@ def generate(
         result["intermediate_quadtree_count"] = intermediate
         result["quadtree_count"] = final
         LOG.debug(
-            f"Processed {csv_converted:,} CSV{'' if csv_converted == 1 else 's'}"
-            f" into {intermediate:,} intermediate quadtree{'' if intermediate == 1 else 's'}"
-            f" and {final:,} region quadtree{'' if final == 1 else 's'}"
+            f"Processed {csv_converted:,} CSV{_s(csv_converted)}"
+            f" into {intermediate:,} intermediate quadtree{_s(intermediate)}"
+            f" and {final:,} region quadtree{_s(final)}"
             f" in {quadtree_timer.duration_s:0.1f} seconds"
         )
 
@@ -160,7 +160,8 @@ def generate(
         result["tile_count"] = tile_count
         result["render_duration_s"] = render_timer.duration_s
         LOG.debug(
-            f"Rendered {tile_count:,} tiles in {render_timer.duration_s:0.1f} seconds"
+            f"Rendered {tile_count:,} tile{_s(tile_count)}"
+            f" in {render_timer.duration_s:0.1f} seconds"
         )
 
     if upload:
@@ -239,9 +240,9 @@ def export_to_csvs(pool, csv_dir):
     def on_progress(tables_complete, table_percent):
         nonlocal result_rows
         LOG.debug(
-            f"  Exported {result_rows:,} row{'' if result_rows==1 else 's'}"
-            f" from {tables_complete:,} table{'' if tables_complete==1 else 's'}"
-            f" to {result_csvs:,} CSV file{'' if result_csvs==1 else 's'}"
+            f"  Exported {result_rows:,} row{_s(result_rows)}"
+            f" from {tables_complete:,} table{_s(tables_complete)}"
+            f" to {result_csvs:,} CSV file{_s(result_csvs)}"
             f" ({table_percent:0.1%})"
         )
 
@@ -351,7 +352,7 @@ def csv_to_quadtrees(pool, csvdir, quadtree_dir):
     def on_merge_progress(merged, percent):
         LOG.debug(
             f"  Merged intermediate quadtrees to {merged:,}"
-            f" quadtree{'' if merged == 1 else 's'} ({percent:0.1%})"
+            f" quadtree{_s(merged)} ({percent:0.1%})"
         )
 
     watch_jobs(merge_jobs, on_progress=on_merge_progress)
@@ -407,13 +408,13 @@ def get_sync_plan(bucket_name, tiles_dir, bucket_prefix="tiles/"):
     LOG.debug(
         f"Completed sync actions in {action_timer.duration_s:0.1f} seconds,"
         f" {len(actions['upload']):,} new"
-        f" tile{'' if len(actions['upload']) == 1 else 's'} to upload,"
+        f" tile{_s(len(actions['upload']))} to upload,"
         f" {len(actions['update']):,} changed"
-        f" tile{'' if len(actions['update']) == 1 else 's'} to update,"
+        f" tile{_s(len(actions['update']))} to update,"
         f" {len(actions['delete']):,} orphaned"
-        f" tile{'' if len(actions['delete']) == 1 else 's'} to delete,"
+        f" tile{_s(len(actions['delete']))} to delete,"
         f" and {unchanged_count:,} unchanged"
-        f" tile{'' if unchanged_count == 1 else 's'}"
+        f" tile{_s(unchanged_count)}"
     )
 
     return actions, unchanged_count
@@ -470,7 +471,7 @@ def sync_tiles(
         nonlocal result, total
         count = sum(result.values())
         percent = count / total
-        LOG.debug(f"  Synced {count:,} file{'' if count == 1 else 's'} ({percent:.1%})")
+        LOG.debug(f"  Synced {count:,} file{_s(count)} ({percent:.1%})")
 
     watch_jobs(jobs, on_progress=on_progress, on_success=on_success, on_error=on_error)
     return result
@@ -616,7 +617,7 @@ def render_tiles_for_zoom_levels(
     tile_params = enumerate_tiles(shapes_dir, max_zoom)
 
     total = len(tile_params)
-    LOG.debug(f"Rendering {total:,} {tile_type}{'' if total == 1 else 's'}...")
+    LOG.debug(f"Rendering {total:,} {tile_type}{_s(tile_type)}...")
 
     # Create the directory structure
     create_tile_subfolders(tile_params, tiles_dir)
@@ -633,9 +634,7 @@ def render_tiles_for_zoom_levels(
     # Watch render jobs to completion
     def on_progress(rendered, percent):
         nonlocal tile_type
-        LOG.debug(
-            f"  Rendered {rendered:,} {tile_type}{'' if rendered == 1 else 's'} ({percent:.1%})"
-        )
+        LOG.debug(f"  Rendered {rendered:,} {tile_type}{_s(tile_type)} ({percent:.1%})")
 
     watch_jobs(jobs, on_progress=on_progress)
     return len(jobs)

--- a/ichnaea/scripts/datamap.py
+++ b/ichnaea/scripts/datamap.py
@@ -407,7 +407,7 @@ def upload_status_file(bucket_name, runtime_data, bucket_prefix="tiles/"):
     )
 
 
-def export_to_csv(filename, tablename, _session=None):
+def export_to_csv(filename, tablename):
     """Export a datamap table to a CSV file."""
     stmt = text(
         """\
@@ -431,9 +431,6 @@ LIMIT :limit
     result_rows = 0
     with open(filename, "w") as fd:
         with db_worker_session(db, commit=False) as session:
-            if _session is not None:
-                # testing hook
-                session = _session
             while True:
                 result = session.execute(stmt.bindparams(limit=limit, grid=min_grid))
                 rows = result.fetchall()

--- a/ichnaea/scripts/tests/test_datamap.py
+++ b/ichnaea/scripts/tests/test_datamap.py
@@ -214,6 +214,7 @@ class TestMap(object):
             max_zoom=2,
         )
         assert set(result.keys()) == {
+            "csv_count",
             "csv_converted_count",
             "export_duration_s",
             "intermediate_quadtree_count",
@@ -227,6 +228,7 @@ class TestMap(object):
         assert result["quadtree_count"] == 2
         assert result["row_count"] == 18
         assert result["tile_count"] == 6
+        assert result["csv_count"] == 2
         assert result["csv_converted_count"] == 2
         assert result["intermediate_quadtree_count"] == 0
 

--- a/ichnaea/scripts/tests/test_datamap.py
+++ b/ichnaea/scripts/tests/test_datamap.py
@@ -11,6 +11,7 @@ from ichnaea.scripts import datamap
 from ichnaea.scripts.datamap import (
     csv_to_quadtree,
     export_to_csv,
+    generate,
     main,
     merge_quadtrees,
     render_tiles,
@@ -155,6 +156,30 @@ class TestMap(object):
         longs = [round(float(line[1]), 2) for line in lines]
         assert set(lats) == set([-10.0, 0.0, 12.35])
         assert set(longs) == set([-11.0, 12.35])
+
+    def test_generate(self, temp_dir, raven, mock_db_worker_session):
+        """generate() calls the steps for tile generation."""
+        result = generate(
+            temp_dir,
+            "bucket_name",
+            raven,
+            create=True,
+            upload=False,
+            concurrency=1,
+            max_zoom=2,
+        )
+        assert set(result.keys()) == {
+            "export_duration_s",
+            "merge_duration_s",
+            "quadtree_count",
+            "quadtree_duration_s",
+            "render_duration_s",
+            "row_count",
+            "tile_count",
+        }
+        assert result["quadtree_count"] == 2
+        assert result["row_count"] == 18
+        assert result["tile_count"] == 6
 
     def test_main(self, raven, temp_dir, mock_main_fixtures):
         """main() calls generate with passed arguments"""

--- a/ichnaea/scripts/tests/test_datamap.py
+++ b/ichnaea/scripts/tests/test_datamap.py
@@ -1,11 +1,12 @@
 import os
 import os.path
+import re
 from multiprocessing import Pool
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, Mock
 
 import pytest
 
-from ichnaea.models.content import DataMap
+from ichnaea.models.content import DataMap, encode_datamap_grid
 from ichnaea.scripts import datamap
 from ichnaea.scripts.datamap import (
     csv_to_quadtree,
@@ -33,27 +34,81 @@ def mock_main_fixtures():
         yield (mock_generate, mock_check_bucket)
 
 
+@pytest.fixture
+def mock_db_worker_session():
+    """
+    Mock the db_worker_session used in export_to_csv()
+
+    Other tests use the database test fixtures, but they can't be used in
+    export_to_csv when called from export_to_csvs, because the test
+    fixtures can't be pickled. This complicated mock works around that
+    limitation by patching db_worker_session directly.
+    """
+
+    class FakeQueryItem:
+        """A fake query row with .grid and .num"""
+
+        def __init__(self, lat, lon):
+            self.grid = encode_datamap_grid(*DataMap.scale(lat, lon))
+            self.num = 0
+
+    # Test data, by database table
+    test_data = {
+        "datamap_ne": [],
+        "datamap_nw": [],
+        "datamap_se": [
+            FakeQueryItem(lat=12.345, lon=12.345),
+            FakeQueryItem(lat=0, lon=12.345),
+        ],
+        "datamap_sw": [FakeQueryItem(lat=-10.000, lon=-11.000)],
+    }
+
+    # The expected SQL statement, with binding placeholders
+    re_stmt = re.compile(
+        r"SELECT `grid`,"
+        r" CAST\(ROUND\(DATEDIFF\(CURDATE\(\), `modified`\) / 30\) AS UNSIGNED\) as `num`"
+        r" FROM (?P<tablename>datamap_[ns][ew])"
+        r" WHERE `grid` > :grid ORDER BY `grid` LIMIT :limit "
+    )
+
+    def get_test_data(statement):
+        """
+        Validate the SQL call and return test data.
+
+        The tablename is extracted from the SQL statement.
+        On the first call, the test data, if any, is returned.
+        On the second call, an empty list is returned.
+        """
+        match = re_stmt.match(statement.text)
+        assert match
+        tablename = match.group("tablename")
+        result = Mock(spec_set=("fetchall", "close"))
+        result.fetchall.return_value = test_data[tablename][:]
+        test_data[tablename] = []  # Return no results on next call
+        return result
+
+    # db_worker_session() returns a context manager
+    mock_context = MagicMock(spec_set=("__enter__", "__exit__"))
+
+    # The context manager returns a session
+    mock_session = Mock(spec_set=["execute"])
+    mock_context.__enter__.return_value = mock_session
+
+    # session.execute(SQL_STATEMENT) returns rows of data
+    mock_session.execute.side_effect = get_test_data
+
+    with patch("ichnaea.scripts.datamap.db_worker_session") as mock_db_worker_session:
+        mock_db_worker_session.return_value = mock_context
+        yield mock_db_worker_session
+
+
 class TestMap(object):
     def _check_quadtree(self, path):
         assert os.path.isdir(path)
         for name in ("1,0", "meta"):
             assert os.path.isfile(os.path.join(path, name))
 
-    def test_files(self, session, temp_dir):
-        today = util.utcnow().date()
-        rows = [
-            dict(time=today, lat=12.345, lon=12.345),
-            dict(time=today, lat=0, lon=12.345),
-            dict(time=today, lat=-10.000, lon=-11.000),
-        ]
-        for row in rows:
-            lat, lon = DataMap.scale(row["lat"], row["lon"])
-            data = DataMap.shard_model(lat, lon)(
-                grid=(lat, lon), created=row["time"], modified=row["time"]
-            )
-            session.add(data)
-        session.flush()
-
+    def test_files(self, temp_dir, mock_db_worker_session):
         lines = []
         rows = 0
 
@@ -65,7 +120,7 @@ class TestMap(object):
         for shard_id, shard in DataMap.shards().items():
             filename = f"map_{shard_id}.csv"
             filepath = os.path.join(temp_dir, filename)
-            result = export_to_csv(filepath, shard.__tablename__, _session=session)
+            result = export_to_csv(filepath, shard.__tablename__)
 
             if not result:
                 assert not os.path.isfile(filepath)
@@ -82,6 +137,7 @@ class TestMap(object):
             assert os.path.isdir(quadfolder)
             self._check_quadtree(quadfolder)
 
+        assert rows
         merge_quadtrees(quaddir, shapes)
         self._check_quadtree(shapes)
 


### PR DESCRIPTION
**Work in Progress** - These changes are being tested on a production server.

For issue #840, make further changes to the datamap script and documentation:

* When an export CSV reached 10,000,000 rows, start writing to multiple CSV files. These are processed into separate quadtree files, which are then merged (duplicates allowed) into the per-table quadtree files, before being merged (eliminating duplicates) into a final whole-world quadtree. This should avoid out-of-memory errors when converting a very large tables from CSV to a quadtree.
* Adjust database mocking method, so that we can test for the ``generate()`` function and the serialized CSV paths.
* Update documentation for new structured logging data.