### PR TITLE
Switch to lts-slim tag

### DIFF
--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.4-slim
+FROM node:lts-slim@sha256:131ed4e7d493f832024ab6a67d650798bd5472980c762b0a96d45e166832d501
 
 # Note: This uses the node user (uid 1000) that comes with the image.
 


### PR DESCRIPTION
Dependabot keeps trying to update to the current node v15 version. I hope that switching to the ``lts-slim`` tag will tell Dependabot to keep updating in the v14 tree until v16 is released.