### PR TITLE
Increase dependabot pull request limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    open-pull-requests-limit: 1000
     reviewers:
       - jwhitlock
   - package-ecosystem: docker
@@ -16,6 +17,7 @@ updates:
     directory: /docker/node/
     schedule:
       interval: monthly
+    open-pull-requests-limit: 1000
     reviewers:
       - jwhitlock
   - package-ecosystem: npm


### PR DESCRIPTION
Dependabot preview was unlimited after you caught up, and now the default is 5, which is too few for effective monthly updates. With https://github.com/willkg/paul-mclendahand, we can handle all the updates.