### PR TITLE
Fix minor docs typo: WSG 84 -> WGS 84

### DIFF
--- a/docs/import_export.rst
+++ b/docs/import_export.rst
@@ -72,13 +72,13 @@ unit
     For example, ``312``.
 
 lon
-    Longitude in degrees between -180.0 and 180.0 using the WSG 84 reference
+    Longitude in degrees between -180.0 and 180.0 using the WGS 84 reference
     system. This is a floating point number.
 
     For example, ``52.3456789``.
 
 lat
-    Latitude in degrees between -90.0 and 90.0 using the WSG 84 reference
+    Latitude in degrees between -90.0 and 90.0 using the WGS 84 reference
     system. This is a floating point number.
 
     For example, ``-10.034``.


### PR DESCRIPTION
Just fixing a minor typo. The correct term for the coordinate system used by GPS is **WGS** 84, standing for World Geodetic System, not "WSG" 84. reference: https://en.wikipedia.org/wiki/World_Geodetic_System