### PR TITLE
Switch to version number in Dockerfile

### DIFF
--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-slim@sha256:7ff9cf5e411481ee734479637265f063c5f356f496d0f9c47112312cb7b46d42
+FROM node:14.17.0-slim
 
 # Note: This uses the node user (uid 1000) that comes with the image.
 


### PR DESCRIPTION
Using ``lts-slim`` as the node tag made it difficult to see what node version is being applied by Dependabot, since the change was just the image hash. Changing back to the version number puts the burden back on the maintainers to stay on the LTS version.

In node news, v14.17.0 is the LTS version, v16 is current, and will become the active LTS version on October 26, 2021. See [Releases](https://nodejs.org/en/about/releases/) for the schedule.