### PR TITLE
Add cache_ok to custom types

### DIFF
--- a/ichnaea/models/sa_types.py
+++ b/ichnaea/models/sa_types.py
@@ -15,6 +15,7 @@ class SetColumn(TypeDecorator):
     """
 
     impl = String
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         if value is not None:
@@ -33,6 +34,7 @@ class TinyIntEnum(TypeDecorator):
     """An IntEnum type stores enum values as tiny integers."""
 
     impl = TinyInteger
+    cache_ok = True
 
     def __init__(self, enum, *args, **kw):
         self.enum = enum
@@ -56,6 +58,7 @@ class TZDateTime(TypeDecorator):
     """
 
     impl = DateTime
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         if isinstance(value, datetime) and value.tzinfo is not None:


### PR DESCRIPTION
Add ``cache_ok`` to mark [custom types as safe](https://docs.sqlalchemy.org/en/14/core/custom_types.html?highlight=cache_ok#sqlalchemy.types.TypeDecorator.cache_ok) as a key for SQL compilation caching. This is required in SQLAlchemy 1.4.14, or a warning is emitted. It has no effect in SQLAlchemy 1.3.