### PR TITLE
Add more `cache_ok` to custom types

### DIFF
--- a/ichnaea/models/cell.py
+++ b/ichnaea/models/cell.py
@@ -303,6 +303,7 @@ class CellAreaColumn(TypeDecorator):
     """A binary type storing Cell Area IDs."""
 
     impl = BINARY
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         if value is None or isinstance(value, bytes):
@@ -325,6 +326,7 @@ class CellIdColumn(TypeDecorator):
     """A binary type storing Cell IDs."""
 
     impl = BINARY
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         if value is None or isinstance(value, bytes):

--- a/ichnaea/models/content.py
+++ b/ichnaea/models/content.py
@@ -74,6 +74,7 @@ class DataMapGridColumn(TypeDecorator):
     """A binary type storing scaled lat/lon grids."""
 
     impl = BINARY
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         if isinstance(value, bytes):

--- a/ichnaea/models/mac.py
+++ b/ichnaea/models/mac.py
@@ -74,6 +74,7 @@ class MacColumn(TypeDecorator):
     """A binary type storing MAC's."""
 
     impl = BINARY
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         if value and len(value) == 6:


### PR DESCRIPTION
SQLAlchemy 1.4.14 emits a warning without this annotation. Each appear to be cache safe. Part of issue #1569.