### PR TITLE
Monitor InnoDB transaction history length, pause observation processing

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -929,10 +929,10 @@ trx_history.purging
 ^^^^^^^^^^^^^^^^^^^
 If the rate controller is enabled, then ``trx_history.purging`` is a gauge that
 becomes ``1`` when the transaction history exceeds the maximum level.
-Observation processing is paused by setting the :ref:`global locate sample rate
-<global-rate-control>` to 0%, which allow the MySQL purge process to reduce the
-transaction history. When it returns to below a safe minimum level, the rate is
-allowed to rise again.
+Observation processing is paused by setting the
+:ref:`global locate sample rate <global-rate-control>` to 0%, which allow the
+MySQL purge process to reduce the transaction history. When it drops below a
+safe minimum level, the rate is allowed to rise again.
 
 If the rate controller is not enabled, then purging mode is not used, and this
 metric is not emitted.

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -58,6 +58,10 @@ Metric Name                      App      Type    Tags
 `submit.request`_                web      counter key, path
 `submit.user`_                   task     gauge   key, interval
 `task`_                          task     timer   task
+`trx_history.length`_            task     gauge
+`trx_history.max`_               task     gauge
+`trx_history.min`_               task     gauge
+`trx_history.purging`_           task     gauge
 ================================ ======== ======= =======================================================
 
 Web Application Metrics
@@ -854,7 +858,8 @@ rate_control.locate
 ^^^^^^^^^^^^^^^^^^^
 ``rate_control.locate`` is a gauge that reports the current setting of the
 :ref:`global locate sample rate <global-rate-control>`, which may be unset
-(100.0), manually set, or set by the rate controller.
+(100.0), manually set, set by the rate controller, or set to 0 by the
+:ref:`transaction history monitor <transaction-history-monitoring>`.
 
 rate_control.locate.target
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -894,6 +899,59 @@ rate_control.locate.dterm
 ``rate_control.locate.dterm`` is a gauge that reports the current value of of
 the derivative term of the rate controller. It is emitted when the rate
 controller is enabled.
+
+.. _transaction-history-metrics:
+
+Transaction History Metrics
+---------------------------
+
+Processing the data queues can cause the MySQL InnoDB transaction history to
+grow faster than it can be purged. The transaction history length can be
+monitored, and when it exceeds a maximum, it can turn off observation
+processing until it is reduced. See
+:ref:`transaction history monitoring <transaction-history-monitoring>`
+for details.
+
+Monitoring the transaction history length requires that the celery worker
+database connection ("read-write") has the ``PROCESS`` privilege. If the
+connection does not have this privilege, then no related metrics are emitted.
+If the connection has this privilege, then one or more metrics are emitted to
+monitor this process:
+
+.. _trx-history-length:
+
+trx_history.length
+^^^^^^^^^^^^^^^^^^
+``trx_history.length`` is a gauge that reports the current length of the
+InnoDB transaction history.
+
+trx_history.purging
+^^^^^^^^^^^^^^^^^^^
+If the rate controller is enabled, then ``trx_history.purging`` is a gauge that
+becomes ``1`` when the transaction history exceeds the maximum level.
+Observation processing is paused by setting the :ref:`global locate sample rate
+<global-rate-control>` to 0%, which allow the MySQL purge process to reduce the
+transaction history. When it returns to below a safe minimum level, the rate is
+allowed to rise again.
+
+If the rate controller is not enabled, then purging mode is not used, and this
+metric is not emitted.
+
+trx_history.max
+^^^^^^^^^^^^^^^
+``trx_history.max`` is a gauge that report the current maximum value for the
+transaction history length before the system switches to purging mode.
+
+If the rate controller is not enabled, then purging mode is not used, and this
+metric is not emitted.
+
+trx_history.min
+^^^^^^^^^^^^^^^
+``trx_history.min`` is a gauge that report the current minimum value for the
+transaction history length before the system switches out of purging mode.
+
+If the rate controller is not enabled, then purging mode is not used, and this
+metric is not emitted.
 
 Datamaps Structured Log
 =======================

--- a/docs/rate_control.rst
+++ b/docs/rate_control.rst
@@ -57,8 +57,24 @@ If traffic is steadily increasing over weeks and months, eventually the backend
 will be unable to recover in a full 24 hour cycle, leading to slower service
 and eventually data loss.
 
+It is possible to have a steady backlog that does not cause issues for Redis,
+but that strains the database resources:
+
+* The primary database can have a large number of write operations, and the
+  replica database, used for read-only operations, can fall behind. This causes
+  a build-up of binary logs on the primary database, filling up the disk. The
+  primary database disk usage and the replica lag should be monitored to detect
+  and prevent this problem.
+* Updates from observations can cause the transaction history / undo logs
+  to grow faster than the purge process can delete them. This causes the
+  system log (``ibdata1``) to grow, and it can't be shrunk without recreating
+  the database. The primary database disk usage and transaction history length
+  should be monitored to prevent this problem.
+
 Ichnaea has rate controls that can be used to sample incoming data, and reduce
-the observations that need to be processed by the backend.
+the observations that need to be processed by the backend. It can also turn
+off processing if the InnoDB transaction history becomes too large. There are
+currently no automated controls for replica lag.
 
 Rate Control by API Key
 =======================
@@ -93,8 +109,8 @@ There is no global rate control for submissions.
 
 .. _auto-rate-controller:
 
-Automated Rate Control (Beta)
-=============================
+Automated Rate Control
+======================
 Optionally, an automated rate controller can set the global locate sample rate.
 The rate controller is given a target of the maximum data queue backlog, and
 periodically compares this to the backlog. It lowers the rate while the backlog
@@ -173,3 +189,46 @@ The rate controller emits several :ref:`metrics <rate-control-metrics>`.
 An administrator can use these metrics to monitor the rate controller, and to
 determine if backend resources should be increased or decreased based on
 long-term traffic trends.
+
+.. _transaction-history-monitoring:
+
+Transaction History Monitoring
+==============================
+Observation processing can cause the InnoDB transaction history or undo logs
+to grow faster than the purge process can delete them. This can cause disk
+usage to grow in a way that can't be reduced without recreating the
+database.
+
+The size of the transaction history can be monitored, if the celery worker
+database connection ("read-write") has the `PROCESS`_ privilege.  To turn on
+transaction history monitoring, ensure this connection can execute the SQL:
+
+.. code-block:: sql
+
+    SELECT count FROM information_schema.innodb_metrics WHERE name = 'trx_rseg_history_len';
+
+.. _`PROCESS`: https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html#priv_process
+
+The transaction history length will be checked at the same time as the queue
+sizes, and will emit a metric :ref:`trx_history.length <trx-history-length>`.
+An administrator can use these metrics to monitor the transaction history
+length, and tune aspects of the MySQL transaction system or backend processing.
+
+Additionally, the automated rate controller can be used to pause processing
+of locate samples and reduce the creation of new transactions. When the
+transaction history length exceeds a maximum size, the global locate sample
+rate is set to 0%. When the MySQL purge process reduces the transaction history
+to a safe level, the rate is allowed to rise again.
+:ref:`Additional metrics <transaction-history-metrics>` are emitted to track
+the process.
+
+To use the rate controller to pause processing:
+
+* Tune the Redis key ``rate_controller_trx_max`` to the maximum history length,
+  such as ``1000000``. This should be set to a number that takes less than a
+  day to clear.
+* Tune the Redis key ``rate_controller_trx_min`` to the minimum history length,
+  such as ``1000``. This should be set to a number that is between 0 and the
+  maximum rate.
+* Set the Redis key ``rate_controller_target`` and ``rate_controller_enabled``
+  as described in :ref:`Automated Rate Control <auto-rate-controller>`.

--- a/docs/rate_control.rst
+++ b/docs/rate_control.rst
@@ -58,18 +58,21 @@ will be unable to recover in a full 24 hour cycle, leading to slower service
 and eventually data loss.
 
 It is possible to have a steady backlog that does not cause issues for Redis,
-but that strains the database resources:
+but that strains the database resources, by increasing replica lag or
+accumulating old transaction logs.
 
-* The primary database can have a large number of write operations, and the
-  replica database, used for read-only operations, can fall behind. This causes
-  a build-up of binary logs on the primary database, filling up the disk. The
-  primary database disk usage and the replica lag should be monitored to detect
-  and prevent this problem.
-* Updates from observations can cause the transaction history / undo logs
-  to grow faster than the purge process can delete them. This causes the
-  system log (``ibdata1``) to grow, and it can't be shrunk without recreating
-  the database. The primary database disk usage and transaction history length
-  should be monitored to prevent this problem.
+The primary database can have a large number of write operations, and the
+replica database, used for read-only operations, can fall behind. This causes a
+build-up of binary logs on the primary database, filling up the disk. It also
+delays changes to API keys, such as adding a key or changing requests limits,
+from being applied to the API. The primary database disk usage and the replica
+lag should be monitored to detect and prevent this problem.
+
+Updates from observations can cause the transaction history / undo logs to grow
+faster than the purge process can delete them. This causes the system log
+(``ibdata1``) to grow, and it can't be shrunk without recreating the database.
+The primary database disk usage and transaction history length should be
+monitored to prevent this problem.
 
 Ichnaea has rate controls that can be used to sample incoming data, and reduce
 the observations that need to be processed by the backend. It can also turn

--- a/ichnaea/data/monitor.py
+++ b/ichnaea/data/monitor.py
@@ -5,6 +5,7 @@ import logging
 
 import markus
 from simple_pid import PID
+from sqlalchemy.exc import OperationalError
 
 from ichnaea import util
 
@@ -77,6 +78,12 @@ class QueueSizeAndRateControl:
     The station data queues represent the backlog, and the rate controller,
     if enabled, attempts to keep the backlog size near a target size by
     adjusting the global locate sample rate.
+
+    Observation processing requires transactions, and the rate of new
+    transactions can exceed the MySQL purge rate. If allowed, monitor
+    this as well, and pause observation processing if it gets too high.
+    Monitoring the transaction history length requires the MySQL user to have
+    the PROCESS permission.
     """
 
     def __init__(self, task):
@@ -89,6 +96,9 @@ class QueueSizeAndRateControl:
         self.rc_kd = None
         self.rc_state = None
         self.rc_controller = None
+        self.trx_history_purging = None
+        self.trx_history_min = None
+        self.trx_history_max = None
 
     def __call__(self):
         """Load components, set the rate, and send metrics."""
@@ -103,9 +113,15 @@ class QueueSizeAndRateControl:
         # The sum of certain queue sizes is the observation backlog
         backlog = self.emit_queue_metrics_and_get_backlog(queue_sizes)
 
+        # Read the MySQL InnoDB transaction history length
+        # Observation processing can cause history to grow faster than purged
+        trx_history_length = self.query_transaction_history_length()
+
         # Use the rate controller to update the global rate
+        # Set the rate to 0% while transaction history is too high
+        # Otherwise, attempt to find a rate that maintains a steady backlog
         if self.rc_enabled:
-            self.run_rate_controller(backlog)
+            self.run_rate_controller(backlog, trx_history_length)
 
         # Emit the current (controlled or manual) global rate
         METRICS.gauge("rate_control.locate", self.rate)
@@ -120,7 +136,21 @@ class QueueSizeAndRateControl:
             pipe.get("rate_controller_ki")
             pipe.get("rate_controller_kd")
             pipe.get("rate_controller_state")
-            rate, rc_enabled, rc_target, rc_kp, rc_ki, rc_kd, rc_state = pipe.execute()
+            pipe.get("rate_controller_trx_purging")
+            pipe.get("rate_controller_trx_min")
+            pipe.get("rate_controller_trx_max")
+            (
+                rate,
+                rc_enabled,
+                rc_target,
+                rc_kp,
+                rc_ki,
+                rc_kd,
+                rc_state,
+                rc_trx_purging,
+                rc_trx_min,
+                rc_trx_max,
+            ) = pipe.execute()
 
         try:
             self.rate = float(rate)
@@ -158,7 +188,7 @@ class QueueSizeAndRateControl:
             return
 
         # Validate simple PID parameters, exit if any are invalid
-        valid = [True] * 4
+        valid = [True] * 7
         self.rc_target, valid[0] = load_param(
             int, "rate_controller_target", rc_target, lambda x: x >= 0
         )
@@ -171,6 +201,20 @@ class QueueSizeAndRateControl:
         self.rc_kd, valid[3] = load_param(
             float, "rate_controller_kd", rc_kd, lambda x: x >= 0, 0
         )
+        self.trx_history_purging, valid[4] = load_param(
+            int, "rate_controller_trx_purging", rc_trx_purging, lambda x: x in {0, 1}, 0
+        )
+        self.trx_history_min, valid[5] = load_param(
+            int, "rate_controller_trx_min", rc_trx_min, lambda x: x > 0, 1000
+        )
+        self.trx_history_max, valid[5] = load_param(
+            int,
+            "rate_controller_trx_max",
+            rc_trx_max,
+            lambda x: x > self.trx_history_min,
+            1000000,
+        )
+
         if not all(valid):
             self.task.redis_client.set("rate_controller_enabled", 0)
             self.task.redis_client.set("rate_controller_state", "{}")
@@ -235,14 +279,48 @@ class QueueSizeAndRateControl:
             METRICS.gauge("queue", size, tags=tags_list)
         return backlog
 
-    def run_rate_controller(self, backlog):
+    def query_transaction_history_length(self):
+        """Get the MySQL InnoDB transaction history length, if allowed."""
+        sql = (
+            "SELECT count FROM information_schema.innodb_metrics"
+            " WHERE name = 'trx_rseg_history_len';"
+        )
+        length = None
+        with self.task.db_session() as session:
+            try:
+                length = session.scalar(sql)
+            except OperationalError as err:
+                # Ignore 1227, 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation')"
+                if err.orig.args[0] != 1227:
+                    raise
+            else:
+                METRICS.gauge("trx_history.length", length)
+        return length
+
+    def run_rate_controller(self, backlog, trx_history_length):
         """Update the rate, monitor and store controller state."""
-        self.update_rate_with_rate_controller(backlog)
-        rc_state = self.freeze_controller_state()
+        trx_purging_mode = self.trx_history_purging_mode(trx_history_length)
+        if trx_purging_mode:
+            self.rate = 0.0
+            rc_state = None
+        else:
+            self.update_rate_with_rate_controller(backlog)
+            rc_state = self.freeze_controller_state()
+
         with self.task.redis_client.pipeline() as pipe:
             pipe.set("global_locate_sample_rate", self.rate)
-            pipe.set("rate_controller_state", rc_state)
+            pipe.set(
+                "rate_controller_trx_purging", 1 if self.trx_history_purging else 0
+            )
+            if rc_state is not None:
+                pipe.set("rate_controller_state", rc_state)
             pipe.execute()
+
+        if trx_history_length is not None:
+            METRICS.gauge("trx_history.min", self.trx_history_min)
+            METRICS.gauge("trx_history.max", self.trx_history_max)
+            METRICS.gauge("trx_history.purging", 1 if self.trx_history_purging else 0)
+
         METRICS.gauge("rate_control.locate.target", self.rc_target)
         METRICS.gauge("rate_control.locate.kp", self.rc_kp)
         METRICS.gauge("rate_control.locate.ki", self.rc_ki)
@@ -252,6 +330,26 @@ class QueueSizeAndRateControl:
         METRICS.gauge("rate_control.locate.pterm", p_term)
         METRICS.gauge("rate_control.locate.iterm", i_term)
         METRICS.gauge("rate_control.locate.dterm", d_term)
+
+    def trx_history_purging_mode(self, trx_history_length):
+        """If transaction history is high, enter purging mode until back to minimum."""
+        if (
+            trx_history_length is None
+            or self.trx_history_purging is None
+            or self.trx_history_min is None
+            or self.trx_history_max is None
+        ):
+            return None
+
+        if trx_history_length > self.trx_history_max:
+            self.trx_history_purging = True
+            return True
+        elif self.trx_history_purging:
+            if trx_history_length < self.trx_history_min:
+                self.trx_history_purging = False
+                return False
+            return True
+        return False
 
     def update_rate_with_rate_controller(self, backlog):
         """Generate a new sample rate."""


### PR DESCRIPTION
For issue #1618, update the queue size and rate control task to also look at the InnoDB transaction history length, if the celery task database user has the ``PROCESS`` permission. This is emitted as a new metric ``trx_history.length``.

This history increases with each transaction, and is decreased by a purge process. If the purge process can't keep up, due to the rate of new transactions, or because there is a transaction left open, then the history will increase, eventually requiring the system tablespace to increase. The system tablespace can not be shrunk without recreating the database, so it is important to keep transaction history within bounds.

If the automated rate controller is active, then a maximum and minimum can be set. When the length exceeds the maximum, then location observation processing is paused by setting the rate to 0%. This allows the transaction purge process to catch up. When the length is back below the minimum safe level, then the rate is allowed to rise again.