### PR TITLE
Use "READ COMMITTED" transaction isolation when counting stations by region

### DIFF
--- a/docs/local_dev.rst
+++ b/docs/local_dev.rst
@@ -304,3 +304,37 @@ You can then generate and upload tiles with::
 
 This will generate a fresh set of tiles in a temporary directory and
 sync the S3 bucket with the changes.
+
+Running Tasks
+=============
+
+To run worker tasks in the development environment, run::
+
+    $ make runcelery
+
+This will run the ``scheduler``, which will schedule periodic tasks, as well as the
+``worker``, which runs the tasks. If you see this error::
+
+    scheduler_1  | ERROR: Pidfile (/var/run/location/celerybeat.pid) already exists.
+
+then stop the ``make runcelery`` process (Ctrl-C) and re-create the ``scheduler``::
+
+    $ docker rm -f scheduler
+    $ make runcelery
+
+To manually run a task, call it from a shell::
+
+    $ make shell
+    $ celery -A ichnaea.taskapp.app:celery_app call ichnaea.data.tasks.update_statregion
+
+This will add the task ``update_statregion`` to the Redis queue. The ``worker`` task
+will read the queue and execute it.
+
+The commands will also run if you start a shell with ``make testshell``, but the task
+will not execute. A different Redis URI is setup for the test environment, and
+the worker running with ``make runcelery`` will not read that Redis queue, and will
+not see the request.
+
+There are other commands available, such as this one to display registered tasks::
+
+    $ celery -A ichnaea.taskapp.app:celery_app inspect registered

--- a/ichnaea/conftest.py
+++ b/ichnaea/conftest.py
@@ -173,7 +173,7 @@ class TestDatabase(Database):
         if shared:
             self.has_session_fixture = False  # Set at session fixture setup
 
-    def session(self, bind=None):
+    def session(self, bind=None, isolation_level=None):
         """Return a thread-local session for this database.
 
         :param bind: Bind the session to a connection, such as a transaction.
@@ -183,7 +183,15 @@ class TestDatabase(Database):
         """
         if self.shared and not self.has_session_fixture:
             raise Exception("Tests must include session fixture to use .session()")
-        return super().session(bind=bind)
+        session = super().session(bind=bind)
+        if isolation_level:
+            session.fake_isolation_level = isolation_level
+        return session
+
+    def engine_with_isolation_level(self, isolation_level):
+        raise Exception(
+            "engine_with_isolation_level should not be called by test code."
+        )
 
 
 @pytest.fixture(scope="session")

--- a/ichnaea/data/stats.py
+++ b/ichnaea/data/stats.py
@@ -102,6 +102,7 @@ class StatRegion(object):
         if counts:
             with self.task.db_session() as session:
                 self._update_stats(counts, session)
+                self._clear_cache()
 
     def _gather_counts(self, session):
         """Count radio sources by region"""
@@ -162,3 +163,7 @@ class StatRegion(object):
                     RegionStat.__table__.c.region.in_(obsolete_regions)
                 )
             )
+
+    def _clear_cache(self):
+        cache_key = self.task.redis_client.cache_keys["stats_regions"]
+        self.task.redis_client.delete(cache_key)

--- a/ichnaea/data/stats.py
+++ b/ichnaea/data/stats.py
@@ -91,14 +91,20 @@ class StatCleaner(object):
 
 
 class StatRegion(object):
+    """Populate the region_stat table, displayed at /stats/regions"""
+
     def __init__(self, task):
         self.task = task
 
     def __call__(self):
-        with self.task.db_session() as session:
-            self._update_stats(session)
+        with self.task.db_session(isolation_level="READ COMMITTED") as session:
+            counts = self._gather_counts(session)
+        if counts:
+            with self.task.db_session() as session:
+                self._update_stats(counts, session)
 
-    def _update_stats(self, session):
+    def _gather_counts(self, session):
+        """Count radio sources by region"""
         columns = CellArea.__table__.c
         cells = session.execute(
             select([columns.region, columns.radio, func.sum(columns.num_cells)])
@@ -107,11 +113,11 @@ class StatRegion(object):
         ).fetchall()
 
         default = {"gsm": 0, "wcdma": 0, "lte": 0, "blue": 0, "wifi": 0}
-        stats = {}
+        counts = {}
         for region, radio, num in cells:
-            if region not in stats:
-                stats[region] = default.copy()
-            stats[region][radio.name] = int(num)
+            if region not in counts:
+                counts[region] = default.copy()
+            counts[region][radio.name] = int(num)
 
         for name, shard_model in (("blue", BlueShard), ("wifi", WifiShard)):
             for shard in shard_model.shards().values():
@@ -123,16 +129,18 @@ class StatRegion(object):
                 ).fetchall()
 
                 for region, num in stations:
-                    if region not in stats:
-                        stats[region] = default.copy()
-                    stats[region][name] += int(num)
+                    if region not in counts:
+                        counts[region] = default.copy()
+                    counts[region][name] += int(num)
 
-        if not stats:
-            return
+        return counts
+
+    def _update_stats(self, counts, session):
+        """Update counts-by-region tables"""
 
         region_stats = dict(session.query(RegionStat.region, RegionStat).all())
 
-        for region, values in stats.items():
+        for region, values in counts.items():
             row = region_stats.pop(region, None)
             is_new = row is None
             if is_new:

--- a/ichnaea/taskapp/task.py
+++ b/ichnaea/taskapp/task.py
@@ -108,14 +108,17 @@ class BaseTask(Task):
         """
         self.apply_async(countdown=self._countdown, args=args, kwargs=kwargs)
 
-    def db_session(self, commit=True):
+    def db_session(self, commit=True, isolation_level=None):
         """
         Returns a database session usable as a context manager.
 
         :param commit: Should the session be committed or aborted at the end?
         :type commit: bool
+        :param isolation_level: Set a new transaction isolation level for this session
         """
-        return db_worker_session(self.app.db, commit=commit)
+        return db_worker_session(
+            self.app.db, commit=commit, isolation_level=isolation_level
+        )
 
     def redis_pipeline(self, execute=True):
         """


### PR DESCRIPTION
For issue #1620, use "READ COMMITTED" transaction isolation when counting stations by region. In production, the large database means these queries take much longer than other queries, and with the default isolation of "READ COMMITTED", MySQL needs to keep track of transactions from other processes until the ``update_statregion`` task is complete.

This mode does not interact well with tests, which use a transaction paired with a rollback to restore the test database after each test. For tests, the custom ``TestDatabase`` ignores the request for ``READ COMMITTED``.

Since I couldn't use tests to check the feature, I instead ran the task in my development environment, which took longer to figure out then expected. I've added some documentation for running async task workers, as well as the commands to queue one of the nightly tasks. 

I've also the task to clear the content cache, so that ``/stats/regions`` will show new data after ``update_statregion`` runs. This affects manual testing as well as when importing a cell data CSV. I tried to also clear the caches so ``/stats`` would update, but it appears that daily updates are baked into this task, and I was unable to get this to display new data. I may try again as part of issue #1403.