### PR TITLE
Dependency updates, August 2021, Round 3: Everett 2.0.0

### DIFF
--- a/ichnaea/conf.py
+++ b/ichnaea/conf.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import
 import os
 import os.path
 
-from everett.component import ConfigOptions, RequiredConfigMixin
-from everett.manager import ConfigManager, ConfigOSEnv
+from everett.manager import ConfigManager, ConfigOSEnv, Option
 
 HERE = os.path.dirname(__file__)
 
@@ -20,103 +19,85 @@ def logging_level_parser(value):
     return value
 
 
-class AppConfig(RequiredConfigMixin):
-    required_config = ConfigOptions()
-    required_config.add_option(
-        "local_dev_env",
-        default="false",
-        parser=bool,
-        doc=(
-            "Whether (True) or not (False) we are in a local dev environment. "
-            "There are some things that get configured one way in a developer's "
-            "environment and another way in a server environment."
-        ),
-    )
-    required_config.add_option(
-        "testing",
-        default="false",
-        parser=bool,
-        doc="Whether or not we are running tests.",
-    )
-    required_config.add_option(
-        "logging_level",
-        default="INFO",
-        parser=logging_level_parser,
-        doc=(
-            "Logging level to use. One of CRITICAL, ERROR, WARNING, INFO, " "or DEBUG."
-        ),
-    )
+class AppComponent:
+    """Everett component for configuring Ichnaea"""
 
-    required_config.add_option(
-        "asset_bucket",
-        default="",
-        doc="name of AWS S3 bucket to store map tile image assets and export downloads",
-    )
-    required_config.add_option(
-        "asset_url",
-        default="",
-        doc="url for map tile image assets and export downloads",
-    )
+    class Config:
+        local_dev_env = Option(
+            doc=(
+                "Whether we are (True) or are not (False) in a local dev"
+                " environment. There are some things that get configured one way"
+                " in a developer's environment and another way in a server"
+                " environment."
+            ),
+            default="false",
+            parser=bool,
+        )
+        testing = Option(
+            doc="Whether or not we are running tests.",
+            default="false",
+            parser=bool,
+        )
+        logging_level = Option(
+            doc=(
+                "Logging level to use. One of CRITICAL, ERROR, WARNING, INFO,"
+                " or DEBUG."
+            ),
+            default="INFO",
+            parser=logging_level_parser,
+        )
+        asset_bucket = Option(
+            doc=(
+                "name of AWS S3 bucket to store map tile image assets and"
+                " export downloads"
+            ),
+            default="",
+        )
+        asset_url = Option(
+            doc="url for map tile image assets and export downloads",
+            default="",
+        )
 
-    # Database related settings
-    required_config.add_option(
-        "db_readonly_uri",
-        doc=(
-            "uri for the readonly database; "
-            "``mysql+pymysql://USER:PASSWORD@HOST:PORT/NAME``"
-        ),
-    )
-    required_config.add_option(
-        "db_readwrite_uri",
-        doc=(
-            "uri for the read-write database; "
-            "``mysql+pymysql://USER:PASSWORD@HOST:PORT/NAME``"
-        ),
-    )
+        # Database related settings
+        db_readonly_uri = Option(
+            doc=(
+                "uri for the readonly database; "
+                "``mysql+pymysql://USER:PASSWORD@HOST:PORT/NAME``"
+            ),
+        )
+        db_readwrite_uri = Option(
+            doc=(
+                "uri for the read-write database; "
+                "``mysql+pymysql://USER:PASSWORD@HOST:PORT/NAME``"
+            ),
+        )
 
-    required_config.add_option(
-        "sentry_dsn",
-        default="",
-        doc="Sentry DSN; leave blank to disable Sentry error reporting",
-    )
-
-    required_config.add_option(
-        "statsd_host", default="", doc="StatsD host; blank to disable StatsD"
-    )
-    required_config.add_option(
-        "statsd_port", default="8125", parser=int, doc="StatsD port"
-    )
-
-    required_config.add_option(
-        "redis_uri", doc="uri for Redis; ``redis://HOST:PORT/DB``"
-    )
-
-    required_config.add_option(
-        "celery_worker_concurrency",
-        parser=int,
-        doc="the number of concurrent Celery worker processes executing tasks",
-    )
-
-    required_config.add_option(
-        "mapbox_token",
-        default="",
-        doc=(
-            "Mapbox API key; if you do not provide this, then parts of the "
-            "site showing maps will be disabled"
-        ),
-    )
-
-    required_config.add_option(
-        "geoip_path",
-        default=os.path.join(HERE, "tests/data/GeoIP2-City-Test.mmdb"),
-        doc="absolute path to mmdb file for GeoIP lookups",
-    )
-
-    required_config.add_option(
-        "secret_key",
-        default="default for development, change in production",
-        doc="a unique passphrase used for cryptographic signing",
-    )
+        sentry_dsn = Option(
+            doc="Sentry DSN; leave blank to disable Sentry error reporting",
+            default="",
+        )
+        statsd_host = Option(doc="StatsD host; blank to disable StatsD", default="")
+        statsd_port = Option(default="8125", parser=int, doc="StatsD port")
+        redis_uri = Option(doc="uri for Redis; ``redis://HOST:PORT/DB``")
+        celery_worker_concurrency = Option(
+            doc="the number of concurrent Celery worker processes executing tasks",
+            parser=int,
+        )
+        mapbox_token = Option(
+            doc=(
+                "Mapbox API key; if you do not provide this, then parts of the "
+                "site showing maps will be disabled"
+            ),
+            default="",
+        )
+        geoip_path = Option(
+            doc="absolute path to mmdb file for GeoIP lookups",
+            default=os.path.join(HERE, "tests/data/GeoIP2-City-Test.mmdb"),
+        )
+        secret_key = Option(
+            doc="a unique passphrase used for cryptographic signing",
+            default="default for development, change in production",
+        )
 
     def __init__(self, config):
         self.raw_config = config
@@ -134,7 +115,7 @@ def build_config_manager():
         ],
         doc="For configuration help, see https://ichnaea.readthedocs.io/",
     )
-    return AppConfig(config_manager)
+    return AppComponent(config_manager)
 
 
 settings = build_config_manager()
@@ -157,7 +138,7 @@ def check_config():
     # These values should be non-empty and non-default
     should_be_set = {"secret_key"}
     for name in should_be_set:
-        default = settings.config.options.options[name].default
+        default = settings.config.options[name][0].default
         value = settings(name)
         if value == default:
             issues.append(f"{name} has the default value '{value}'")

--- a/requirements.in
+++ b/requirements.in
@@ -48,7 +48,7 @@ dockerflow==2021.7.0
 # Code: https://github.com/willkg/everett
 # Changes: https://github.com/willkg/everett/blob/main/HISTORY.rst
 # Docs: https://everett.readthedocs.io
-everett==1.0.3
+everett==2.0.0
 
 # Geopolitical Entities, Names, and Codes (GENC)
 # Code: https://github.com/hannosch/genc

--- a/requirements.txt
+++ b/requirements.txt
@@ -308,9 +308,9 @@ docutils==0.16 \
     # via
     #   sphinx
     #   sphinx-rtd-theme
-everett==1.0.3 \
-    --hash=sha256:2c4cb84700a122e5bbc82b1808c22e1f0c17af0c1e0c84711e0e43cb1f7b932d \
-    --hash=sha256:6612917b7bd9c1568a63eabdf04701791f7bb05cbf302eb5dc2b6f1aeb68c61e
+everett==2.0.0 \
+    --hash=sha256:83f319300c950e5935a2399fab2f5ac07eb6b8421cafae7974d1884306b5b3e4 \
+    --hash=sha256:f4463e036f6e10ae2069a90cdcd77ab8ad5ac9242984e005dafdf146e8369b9e
     # via -r requirements.in
 factory-boy==3.2.0 \
     --hash=sha256:1d3db4b44b8c8c54cdd8b83ae4bdb9aeb121e464400035f1f03ae0e1eade56a4 \


### PR DESCRIPTION
* Bump everett from 1.0.3 to 2.0.0 (from PR #1656)
* Update configuration for Everett 2.0. This is mostly rearranging for the new ``Option`` format, but the diff makes it look like a rewrite. The internals of the configuration changed as well, which I peek at to see if the ``SECRET_KEY`` was set in production.
