### PR TITLE
Create cross-platform docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ commands:
             docker-compose --version | tee -a << parameters.info_path >>
             echo "*** docker compose --version ***" | tee -a << parameters.info_path >>
             docker compose --version | tee -a << parameters.info_path >>
+            echo "*** docker buildx inspect --bootstrap ***" | tee -a << parameters.info_path >>
+            docker buildx inspect --bootstrap | tee -a << parameters.info_path >>
       - store_artifacts:
           path: << parameters.info_path >>
           destination: << parameters.artifact_path >>
@@ -104,6 +106,9 @@ jobs:
       image: ubuntu-2004:202111-02
     environment:
       BUILDKIT_PROGRESS: plain
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64
+      BUILDX_VERSION: v0.7.1
 
     steps:
         - run:
@@ -113,6 +118,24 @@ jobs:
                 echo "Skipping Docker push for forked PRs."
                 circleci step halt
               fi
+        - run:
+            name: Install buildx
+            working_directory: /tmp
+            command: |
+              BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-amd64"
+              echo "Downloading from ${BUILDX_BINARY_URL}..."
+              curl --output docker-buildx \
+                --no-progress-meter --show-error --location --fail --retry 3 \
+                "$BUILDX_BINARY_URL"
+
+              mkdir -p ~/.docker/cli-plugins
+
+              mv docker-buildx ~/.docker/cli-plugins/
+              chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+              docker buildx install
+              # Run binfmt to install platform builders
+              docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
         - run:
             name: Setup checkout directory
             command: |
@@ -127,12 +150,7 @@ jobs:
             artifact_path: /tmp/build_info.txt
         - login_to_dockerhub
         - run:
-            name: Build Docker images
-            working_directory: /ichnaea
-            command: |
-              make build
-        - run:
-            name: Push to Dockerhub
+            name: Build cross-platform images and Push to Dockerhub
             working_directory: /ichnaea
             command: |
               function retry {
@@ -140,15 +158,15 @@ jobs:
                 local n=0
                 local max=3
                 while true; do
-                "$@" && break || {
-                  if [[ $n -lt $max ]]; then
-                    ((n++))
-                    echo "Command failed. Attempt $n/$max:"
-                  else
-                    echo "Failed after $n attempts."
-                    exit 1
-                  fi
-                }
+                  "$@" && break || {
+                    if [[ $n -lt $max ]]; then
+                      ((n++))
+                      echo "Command failed. Attempt $n/$max:"
+                    else
+                      echo "Failed after $n attempts."
+                      exit 1
+                    fi
+                  }
                 done
                 set -e
               }
@@ -159,13 +177,15 @@ jobs:
                 export DOCKER_TAG="${CIRCLE_SHA1}"
               fi
 
-              docker tag "local/ichnaea_app" "mozilla/location:${DOCKER_TAG}"
-              retry docker push "mozilla/location:${DOCKER_TAG}"
+              # Cross-build the tagged version
+              export BUILDX_PLATFORMS=${BUILDX_PLATFORMS}
+              export CROSS_BUILD_ARGS="--tag \"mozilla/location:${DOCKER_TAG}\" --push"
+              retry make cross-build
 
-              # push `latest` on main only
+              # Cross-build and push `latest` on main only
               if [ "${CIRCLE_BRANCH}" == "main" ]; then
-                docker tag "local/ichnaea_app" "mozilla/location:latest"
-                retry docker push "mozilla/location:latest"
+                export CROSS_BUILD_ARGS="--tag \"mozilla/location:latest\" --push"
+                retry make cross-build
               fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,5 +205,3 @@ workflows:
           filters:
             tags:
               only: /.*/
-            branches:
-              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,85 +1,136 @@
 version: 2.1
+
+commands:
+  capture_host_info:
+    description: "Capture Host information"
+    parameters:
+      info_path:
+        type: string
+        default: "/tmp/info.txt"
+      artifact_path:
+        type: string
+        default: "/tmp/info.txt"
+    steps:
+      - run:
+          name: "Get Host Information"
+          command: |
+            echo "*** uname -v ***" | tee << parameters.info_path >>
+            uname -v | tee -a << parameters.info_path >>
+            echo "*** docker info ***" | tee -a << parameters.info_path >>
+            docker info | tee -a << parameters.info_path >>
+            echo "*** docker-compose --version ***" | tee -a << parameters.info_path >>
+            docker-compose --version | tee -a << parameters.info_path >>
+            echo "*** docker compose --version ***" | tee -a << parameters.info_path >>
+            docker compose --version | tee -a << parameters.info_path >>
+      - store_artifacts:
+          path: << parameters.info_path >>
+          destination: << parameters.artifact_path >>
+  create_version_json:
+    description: "Create version.json for Dockerflow"
+    parameters:
+      path:
+        type: string
+        default: "/ichnaea/version.json"
+    steps:
+      - run:
+          name: Create version.json
+          command: |
+            # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
+            printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
+            "$CIRCLE_SHA1" \
+            "$CIRCLE_TAG" \
+            "$CIRCLE_PROJECT_USERNAME" \
+            "$CIRCLE_PROJECT_REPONAME" \
+            "$CIRCLE_BUILD_URL" > << parameters.path >>
+      - store_artifacts:
+          path: << parameters.path >>
+  login_to_dockerhub:
+    description: "Login to Dockerhub, to avoid rate limits"
+    steps:
+      - run:
+          name: Login to Dockerhub
+          command: |
+            if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
+              echo "Skipping Login to Dockerhub, credentials not available."
+            else
+              echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
+            fi
+
 jobs:
-  build:
+  test:
     docker:
       - image: mozilla/cidockerbases:docker-latest
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     working_directory: /
+    environment:
+      BUILDKIT_PROGRESS: plain
 
     steps:
-        - run:
-            name: Host info
-            command: uname -v
-
-        - run:
-            name: Install essential packages
-            command: |
-                apt-get update
-
         - checkout:
             path: /ichnaea
-
-        - run:
-            name: Create version.json
-            working_directory: /ichnaea
-            command: |
-                # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
-                printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
-                "$CIRCLE_SHA1" \
-                "$CIRCLE_TAG" \
-                "$CIRCLE_PROJECT_USERNAME" \
-                "$CIRCLE_PROJECT_REPONAME" \
-                "$CIRCLE_BUILD_URL" > /ichnaea/version.json
-
-        - store_artifacts:
+        - create_version_json:
             path: /ichnaea/version.json
-
         - run:
             name: Install Docker Compose
             command: |
-                set +x
-                curl -L https://github.com/docker/compose/releases/download/1.27.4/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-                chmod +x /usr/local/bin/docker-compose
-
+              set +x
+              curl -L https://github.com/docker/compose/releases/download/1.27.4/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+              chmod +x /usr/local/bin/docker-compose
         - setup_remote_docker:
-            version: 20.10.6
-
-        - run:
-            name: Get Info
-            command: |
-               docker info
-               which docker-compose
-               docker-compose --version
-
-        - run:
-            name: Login to Dockerhub
-            command: |
-                if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
-                  echo "Skipping Login to Dockerhub, credentials not available."
-                else
-                  echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
-                fi
-
+            version: 20.10.11
+        - capture_host_info:
+            info_path: /tmp/test_info.txt
+            artifact_path: /tmp/test_info.txt
+        - login_to_dockerhub
         - run:
             name: Build Docker images
             working_directory: /ichnaea
             command: |
-                make build
-
+              make build
         - run:
             name: Run linting
             working_directory: /ichnaea
             command: |
-                docker run local/ichnaea_app shell ./docker/run_lint.sh
-
+              docker run local/ichnaea_app shell ./docker/run_lint.sh
         - run:
             name: Run tests
             working_directory: /ichnaea
             command: |
-                make test
+              make test
+  build-push:
+    machine:
+      image: ubuntu-2004:202111-02
+    environment:
+      BUILDKIT_PROGRESS: plain
 
+    steps:
+        - run:
+            name: Stop if build is for pull request from a fork.
+            command: |
+              if [ -n "$CIRCLE_PR_NUMBER" ]; then
+                echo "Skipping Docker push for forked PRs."
+                circleci step halt
+              fi
+        - run:
+            name: Setup checkout directory
+            command: |
+              sudo mkdir -p /ichnaea
+              sudo chmod a+rwx /ichnaea
+        - checkout:
+            path: /ichnaea
+        - create_version_json:
+            path: /ichnaea/version.json
+        - capture_host_info:
+            info_path: /tmp/build_info.txt
+            artifact_path: /tmp/build_info.txt
+        - login_to_dockerhub
+        - run:
+            name: Build Docker images
+            working_directory: /ichnaea
+            command: |
+              make build
         - run:
             name: Push to Dockerhub
             working_directory: /ichnaea
@@ -102,22 +153,19 @@ jobs:
                 set -e
               }
 
-              export DOCKER_TAG="${CIRCLE_SHA1}"
               if [ -n "${CIRCLE_TAG}" ]; then
                 export DOCKER_TAG="${CIRCLE_TAG}"
-              fi
-              # push on main or git tag
-              if [ "${CIRCLE_BRANCH}" == "main" ] || [ -n "${CIRCLE_TAG}" ]; then
-                docker tag "local/ichnaea_app" "mozilla/location:${DOCKER_TAG}"
-                retry docker push "mozilla/location:${DOCKER_TAG}"
-
-                # push `latest` on main only
-                if [ "${CIRCLE_BRANCH}" == "main" ]; then
-                  docker tag "local/ichnaea_app" "mozilla/location:latest"
-                  retry docker push "mozilla/location:latest"
-                fi
               else
-                echo "Skipping Push to Dockerhub, not main or tag."
+                export DOCKER_TAG="${CIRCLE_SHA1}"
+              fi
+
+              docker tag "local/ichnaea_app" "mozilla/location:${DOCKER_TAG}"
+              retry docker push "mozilla/location:${DOCKER_TAG}"
+
+              # push `latest` on main only
+              if [ "${CIRCLE_BRANCH}" == "main" ]; then
+                docker tag "local/ichnaea_app" "mozilla/location:latest"
+                retry docker push "mozilla/location:latest"
               fi
 
 workflows:
@@ -125,9 +173,17 @@ workflows:
   #
   # workflow jobs are _not_ run in tag builds by default, so we have to enable that.
   # see: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
-  build-test-push:
+  test-build-push:
     jobs:
-      - build:
+      - test:
           filters:
             tags:
               only: /.*/
+      - build-push:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: main

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,12 @@ ifeq (1, ${NOCACHE})
 DOCKER_BUILD_OPTS := --no-cache
 endif
 
+# Set this to override the cross-build paramters
+BUILDX_PLATFORMS?=linux/amd64,linux/arm64
+CROSS_BUILD_ARGS?=
+
 DC := $(shell which docker-compose)
+DOCKER := $(shell which docker)
 
 .PHONY: help
 help: default
@@ -48,6 +53,7 @@ default:
 	@echo "  update-vendored  - re-download vendor source and test data"
 	@echo "  update-reqs      - regenerate Python requirements"
 	@echo "  local-map        - generate local map tiles"
+	@echo "  cross-build      - build cross-platform docker containers"
 	@echo ""
 	@echo "  help             - see this text"
 	@echo ""
@@ -80,6 +86,16 @@ build: my.env
 	${DC} build ${DOCKER_BUILD_OPTS} \
 	    redis db
 	touch .docker-build
+
+.PHONY: cross-build
+cross-build: my.env
+	${DOCKER} buildx create --node ichnaea-cross-build --use
+	${DOCKER} buildx build \
+	    --platform ${BUILDX_PLATFORMS} \
+	    --build-arg userid=${ICHNAEA_UID} \
+	    --build-arg groupid=${ICHNAEA_GID} \
+	    ${CROSS_BUILD_ARGS} \
+	    .
 
 .PHONY: setup
 setup: my.env


### PR DESCRIPTION
For issue #1636, create Docker images with `linux/amd64` and `linux/arm64` variants.  This uses techniques described on the tutorial [Building Docker images for multiple operating system architectures](https://circleci.com/blog/building-docker-images-for-multiple-os-architectures/).

This add ``make cross-build`` to run ``docker buildx`` to build the multi-platform images, but doesn't ensure that ``buildx`` is installed and configured.

The CircleCI configuration is changed to use a machine image, using similar but slightly different steps.  The bundled ``docker`` is used, and version details are logged and added to an artifact.  A ``when`` step is used to determine if we're building a tag or the ``main`` branch. If this is the case, then ``buildx`` is installed and configured, and used to build the image tagged with the SHA1 / tag name, as well as the ``latest`` tag if it is the main branch.