### PR TITLE
Dependency updates, February 2022, Part 1 - Language updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.9-slim
+FROM python:3.10.2-slim
 
 # Set up user and group.
 ARG groupid=10001

--- a/docker.make
+++ b/docker.make
@@ -77,7 +77,7 @@ build_geocalc:
 
 build_check:
 	@which encode enumerate merge render pngquant
-	$(PYTHON) -c "import sys; from shapely import speedups; sys.exit(not speedups.available)"
+	$(PYTHON) -c "import sys; from shapely import speedups, __version__; print(f'{speedups.available=}, {__version__=}'); sys.exit(not (speedups.available or __version__=='1.8.0'))"
 	$(PYTHON) -c "import geocalc"
 	$(PYTHON) -c "import sys; from ichnaea.geoip import GeoIPWrapper; sys.exit(not GeoIPWrapper('ichnaea/tests/data/GeoIP2-City-Test.mmdb').check_extension())"
 	$(PYTHON) -c "import sys; from ichnaea.geocode import GEOCODER; sys.exit(not GEOCODER.region(51.5, -0.1) == 'GB')"

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.1-slim
+FROM node:16.13.2-slim
 
 # Note: This uses the node user (uid 1000) that comes with the image.
 


### PR DESCRIPTION
Disable speedups check for Shapely 1.8.0. This is used for region from lat/long estimate, which is not currently used by any clients.

Then, update the language versions:

* Bump python from 3.9.9-slim to 3.10.2-slim (from PR #1765)
* Bump node from 16.13.1-slim to 16.13.2-slim in /docker/node (from PR #1766)

