### PR TITLE
Upgrade everett from 2.0.1 to 3.0.0

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -17,9 +17,9 @@ inside database tables.
 Environment variables
 =====================
 
-.. autocomponent:: ichnaea.conf.AppComponent
-   :hide-classname:
+.. autocomponentconfig:: ichnaea.conf.AppComponent
    :case: upper
+   :show-table:
 
 
 Alembic requires an additional item in the environment:

--- a/ichnaea/conf.py
+++ b/ichnaea/conf.py
@@ -138,7 +138,8 @@ def check_config():
     # These values should be non-empty and non-default
     should_be_set = {"secret_key"}
     for name in should_be_set:
-        default = settings.config.options[name][0].default
+        option = getattr(AppComponent.Config, name)
+        default = option.default
         value = settings(name)
         if value == default:
             issues.append(f"{name} has the default value '{value}'")

--- a/requirements.in
+++ b/requirements.in
@@ -48,7 +48,7 @@ dockerflow==2022.1.0
 # Code: https://github.com/willkg/everett
 # Changes: https://github.com/willkg/everett/blob/main/HISTORY.rst
 # Docs: https://everett.readthedocs.io
-everett==2.0.1
+everett==3.0.0
 
 # Geopolitical Entities, Names, and Codes (GENC)
 # Code: https://github.com/hannosch/genc

--- a/requirements.txt
+++ b/requirements.txt
@@ -304,9 +304,9 @@ docutils==0.16 \
     # via
     #   sphinx
     #   sphinx-rtd-theme
-everett==2.0.1 \
-    --hash=sha256:2a08c4401ddd707f3161927e11a817cdaebabd71447f6a962612ec74b91e3898 \
-    --hash=sha256:f79bc7abc1a9f5b0db54dbfee3408eb0b3afd9f8040a4e77cc824e0347a6034d
+everett==3.0.0 \
+    --hash=sha256:43c208e09ef53adb8e8739ad96999893a2c0a27753e33f89be346e916e71efb0 \
+    --hash=sha256:80ce592168ce50643711eceff3ec94fdeec755f228de746f20b1bfc94ea20682
     # via -r requirements.in
 factory-boy==3.2.1 \
     --hash=sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e \


### PR DESCRIPTION
This includes https://github.com/mozilla/ichnaea/pull/1778, and also:

* Updates `check_config()` to use ``AppComponent.Config`` instead of the undocumented v2 implemention
* Update the documentation with the new `autocomponentconfig` directive