### PR TITLE
Update to redis 6.2.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - "3306"
 
   redis:
-    image: redis:3.2
+    image: redis:6.2
     expose:
       - "6379"
     ports:


### PR DESCRIPTION
Update to use redis 6.2.7.

Redis's release policy is a new major version once a year, and a minor version after about 6 months. Version 7 is in development, and 5 is the oldest supported version.

https://redis.io/docs/about/releases/