### PR TITLE
Send SENTRY_ENVIRONMENT to Sentry

### DIFF
--- a/ichnaea/conf.py
+++ b/ichnaea/conf.py
@@ -76,6 +76,7 @@ class AppComponent:
             doc="Sentry DSN; leave blank to disable Sentry error reporting",
             default="",
         )
+        sentry_environment = Option(doc="Sentry environment", default="")
         statsd_host = Option(doc="StatsD host; blank to disable StatsD", default="")
         statsd_port = Option(default="8125", parser=int, doc="StatsD port")
         redis_uri = Option(doc="uri for Redis; ``redis://HOST:PORT/DB``")

--- a/ichnaea/log.py
+++ b/ichnaea/log.py
@@ -157,10 +157,17 @@ def configure_raven(transport=None, tags=None, _client=None):
         raise ValueError("No valid raven transport was configured.")
 
     dsn = settings("sentry_dsn")
+    environment = settings("sentry_environment")
     klass = DebugRavenClient if not dsn else RavenClient
     info = version_info()
     release = info.get("version") or info.get("commit") or "unknown"
-    client = klass(dsn=dsn, transport=transport, release=release, tags=tags or {})
+    client = klass(
+        dsn=dsn,
+        transport=transport,
+        release=release,
+        environment=environment or None,
+        tags=tags or {},
+    )
     return client
 
 


### PR DESCRIPTION
The new library, `sentry_sdk`, will pick this environment variable up automatically. We need to explicitly set it for Raven.