### PR TITLE
Removing 1 second delay for data tasks that are ready to be processed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ichnaea/content/static/datamap/tiles/
 
 my.env
 .docker-build
+.vscode/

--- a/ichnaea/data/tasks.py
+++ b/ichnaea/data/tasks.py
@@ -99,9 +99,7 @@ def update_incoming(self):
     export.IncomingQueue(self)(export_reports)
 
 
-@celery_app.task(
-    base=BaseTask, bind=True, queue="celery_export", expires=300
-)
+@celery_app.task(base=BaseTask, bind=True, queue="celery_export", expires=300)
 def export_reports(self, name, queue_key):
     export.ReportExporter.export(self, name, queue_key)
 

--- a/ichnaea/data/tasks.py
+++ b/ichnaea/data/tasks.py
@@ -100,7 +100,7 @@ def update_incoming(self):
 
 
 @celery_app.task(
-    base=BaseTask, bind=True, queue="celery_export", _countdown=1, expires=300
+    base=BaseTask, bind=True, queue="celery_export", expires=300
 )
 def export_reports(self, name, queue_key):
     export.ReportExporter.export(self, name, queue_key)


### PR DESCRIPTION
Relates to issue https://github.com/mozilla/ichnaea/issues/2043 - the data queues can get backed up causing data to be lost. 

This removes an unnecessary 1 second delay between processing batches of records. On the surface this doesn't seem like much, but in local testing it makes a huge difference and will hopefully alleviate the issue.